### PR TITLE
Import the `publish()` command from -core

### DIFF
--- a/datalad_deprecated/__init__.py
+++ b/datalad_deprecated/__init__.py
@@ -14,6 +14,10 @@ command_suite = (
             'datalad_deprecated.ls',
             'Ls',
         ),
+        (
+            'datalad_deprecated.publish',
+            'Publish',
+        ),
     ]
 )
 

--- a/datalad_deprecated/publish.py
+++ b/datalad_deprecated/publish.py
@@ -1,0 +1,844 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""High-level interface for dataset (component) publishing
+
+"""
+
+import logging
+import re
+from collections import OrderedDict
+from os.path import join as opj
+
+from datalad import ssh_manager
+from datalad.interface.annotate_paths import (
+    AnnotatePaths,
+    annotated2content_by_ds
+)
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.utils import eval_results
+from datalad.interface.results import get_status_dict
+from datalad.interface.common_opts import annex_copy_opts, recursion_flag, \
+    recursion_limit, git_opts, annex_opts, jobs_opt
+from datalad.interface.common_opts import missing_sibling_opt
+from datalad.support.param import Parameter
+from datalad.support.constraints import (
+    EnsureStr,
+    EnsureChoice,
+    EnsureNone,
+)
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.sshconnector import sh_quote
+from datalad.support.exceptions import (
+    InsufficientArgumentsError,
+)
+from datalad.support.network import (
+    is_ssh,
+    RI,
+    URL,
+)
+
+from datalad.utils import ensure_list
+
+from .dataset import EnsureDataset
+from .dataset import Dataset
+from .dataset import datasetmethod
+from .dataset import require_dataset
+
+__docformat__ = 'restructuredtext'
+
+lgr = logging.getLogger('datalad.distribution.publish')
+
+
+def _push(ds, remote, things2push, force=False):
+    lgr.debug("Attempt to push '%s' to sibling '%s'", things2push, remote)
+    push_res = ds.repo.push(remote=remote, refspec=things2push, force=force)
+    if things2push and ds.config.get('remote.{}.push'.format(remote)):
+        # we aim to push both auto-detected and possibly configured once
+        # above we pushed the result of auto-detection, now push the
+        # configured ones
+        lgr.debug("Secondary push since custom push targets provided")
+        push_res.extend(
+            ds.repo.push(remote=remote, force=force))
+    if not push_res:
+        return 'notneeded', 'Git reported nothing was pushed'
+    errors = [
+        '{} -> {} {}'.format(
+            pi['from_ref'],
+            pi['to_ref'],
+            pi['note'])
+        for pi in push_res
+        if 'error' in pi['operations']]
+    successes = [
+        pi['note']
+        for pi in push_res
+        if 'error' not in pi['operations']]
+    if errors:
+        return 'error', \
+               ('failed to push to %s: %s;%s',
+                remote,
+                '; '.join(errors),
+                ' pushed: {}'.format(successes) if successes else '')
+    else:
+        return 'ok', ('pushed to %s: %s', remote, successes)
+
+
+def _get_remote_branch(ds, refspec=None):
+    if refspec:
+        remote_branch_name = refspec[11:] \
+            if refspec.startswith('refs/heads/') \
+            else refspec
+    else:
+        # there was no tracking branch, check the push target
+        remote_branch_name = ds.repo.get_active_branch()
+    return remote_branch_name
+
+
+def has_diff(ds, remote_branch_name, remote, paths):
+    """Return bool if a dataset was modified wrt to a given remote state"""
+    remote_ref = '/'.join((remote, remote_branch_name))
+    if remote_ref not in ds.repo.get_remote_branches():
+        lgr.debug("Remote '%s' has no branch matching %r. Will publish",
+                  remote, remote_branch_name)
+        # we don't have any remote state, need to push for sure
+        return True
+
+    lgr.debug("Testing for changes with respect to '%s' of remote '%s'",
+              remote_branch_name, remote)
+    current_commit = ds.repo.get_hexsha()
+    within_ds_paths = [p['path'] for p in paths if p['path'] != ds.path]
+    commit_differ = current_commit != ds.repo.get_hexsha(remote_ref)
+    # yoh: not sure what "logic" was intended here for comparing only
+    # some files.  By now we get a list of files, if any were changed,
+    # from the commit on remote, and somehow diff says below that they didn't differ...
+    # but if commit is different -- there must be differences and we
+    # should publish. otherwise now skips publishing root dataset
+    # although its master is behind by 1 commit.  Moreover there could
+    # be an empty commit -- shouldn't we publish then???
+    if not commit_differ and within_ds_paths:
+        # only if any paths is different from just the parentds root
+        # in which case we can do the same muuuch cheaper (see below)
+        # if there were custom paths, we will look at the diff
+        lgr.debug("Since paths provided, looking at diff")
+        return any(r["state"] != "clean"
+                   for r in ds.diff(path=within_ds_paths,
+                                    fr="HEAD",
+                                    to=remote_ref,
+                                    untracked="no"))
+    else:
+        # if commits differ at all
+        lgr.debug("Since no paths provided, comparing commits")
+        return commit_differ
+
+
+def _publish_data(ds, remote, paths, annex_copy_options, force, transfer_data, **kwargs):
+    # paths are annotated paths for now, changes below
+    if not isinstance(ds.repo, AnnexRepo):
+        # impossible to publish annex'ed data
+        return
+
+    if ds.config.getbool('remote.{}'.format(remote), 'annex-ignore', False):
+        # configuration says: don't do it
+        return
+
+    if not ds.config.get('.'.join(('remote', remote, 'annex-uuid')), None):
+        # this remote either isn't an annex, or hasn't been properly initialized
+        for ap in paths:
+            # this is only a problem if this path
+            ap['status'] = 'impossible' \
+                           if transfer_data == 'all' or ap.get('raw_input', False) \
+                           else 'notneeded'
+            ap['message'] = \
+                ("annex for remote '%s' not available, or not properly configured",
+                 remote)
+            yield ap
+        return
+
+    # what data to transfer?
+    if transfer_data == 'all':
+        paths = ['.']
+    elif transfer_data == 'auto':
+        # keep only paths that were requested and are not the base path of the dataset
+        # if the resulting list is empty, the "auto" mode of _publish_data() will
+        # kick in and consult "wanted"
+        paths = [p['path'] for p in paths
+                 if p.get('raw_input', False) and
+                 not p['path'] == ds.path]
+    else:
+        raise ValueError(
+            "unknown label '{}' for `transfer_data` option".format(
+                transfer_data))
+
+    # TODO do we really have to call annex for that, or can we take it from
+    # the config instead?
+    remote_wanted = ds.repo.get_preferred_content('wanted', remote)
+    if not (paths or annex_copy_options or remote_wanted):
+        # nothing that we could tell git annex
+        return
+
+    # we should now know what needs doing
+    lgr.info("Publishing {0} data to {1}".format(ds, remote))
+    # overwrite URL with pushurl if any, reason:
+    # https://git-annex.branchable.com/bugs/annex_ignores_pushurl_and_uses_only_url_upon___34__copy_--to__34__/
+    # Note: This shouldn't happen anymore with newly added siblings.
+    #       But for now check for it, until we agree on how to fix existing
+    #       ones.
+    pushurl = ds.config.get('remote.{}.pushurl'.format(remote), None)
+    annexurl = ds.config.get('remote.{}.annexurl'.format(remote), None)
+    annex_copy_options_ = annex_copy_options or ''
+    if pushurl and not annexurl:
+        annex_copy_options_ += ' -c "remote.{}.annexurl={}"'.format(remote, pushurl)
+    if not paths and remote_wanted:
+        lgr.debug("Invoking copy --auto")
+        annex_copy_options_ += ' --auto'
+    # TODO:  we might need additional logic comparing the state of git-annex
+    # branch locally and on remote to see if information about the 'copy'
+    # was also reflected on the remote end
+    #git_annex_hexsha = ds.repo.get_hexsha('git-annex')
+    # TODO: must be the same if we merged/pushed before, if not -- skip
+    # special logic may be with a warning
+    if not force:
+        # if we force, we do not trust local knowledge and do the checks
+        annex_copy_options_ += ' --fast'
+    # TODO this things needs to return JSON
+    ncopied = 0
+    for r in ds.repo.copy_to(
+            files=[p for p in paths
+                   # TODO we may have to check for any file in Git, but this one can
+                   # easily happen with --since
+                   if not p == opj(ds.path, '.gitmodules')],
+            remote=remote,
+            options=annex_copy_options_):
+        ncopied += 1
+        # TODO RF to have copy_to() yield JSON and convert that one
+        # at present only the "good" results come out
+        yield get_status_dict(status='ok', path=opj(ds.path, r),
+                              type='file', parentds=ds.path, **kwargs)
+
+    if ncopied:
+        _check_and_update_remote_server_info(ds, remote)
+
+    # if ds.submodules:
+    #     # NOTE: we might need to init them on the remote, but needs to
+    #     #  be done only if remote is sshurl and it is not bare there
+    #     #  (which I think we do not even support ATM)...
+    #     #  or we could do that in the hook, as it is done for now
+    #     #  (see create_sibling.py)
+    #     #
+    #     pass
+
+    # TODO unclear why this was commented out
+    # if ds.repo.get_hexsha('git-annex') != git_annex_hexsha:
+    #     # there were changes which should be pushed
+    #     lgr.debug(
+    #         "We have progressed git-annex branch should fetch/merge/push it to %s again",
+    #         remote)
+    #     ds.repo.fetch(remote=remote, refspec='git-annex')
+    #     ds.repo.merge_annex(remote)
+    #     _log_push_info(ds.repo.push(remote=remote, refspec=['git-annex']))
+
+
+def _check_and_update_remote_server_info(ds, remote):
+    # if we managed to copy to "http" url  we should should try to trigger git
+    # update-server-info hook on the remote if there was ssh annexurl defined
+    # for it. Apparently we do that already in create_sibling ones, but here
+    # we need more checks and preparation
+    remote_url = ds.repo.config.get('remote.%s.url' % remote, None)
+    if remote_url:
+        remote_url = RI(remote_url)
+        if isinstance(remote_url, URL) and remote_url.scheme in (
+        'http', 'https'):
+            remote_annexurl = ds.repo.config.get('remote.%s.annexurl' % remote,
+                                                 None)
+            if remote_annexurl:
+                remote_annexurl_ri = RI(remote_annexurl)
+                if is_ssh(remote_annexurl_ri):
+                    ssh = ssh_manager.get_connection(remote_annexurl_ri)
+                    ssh('git -C {} update-server-info'.format(
+                        sh_quote(remote_annexurl_ri.path)))
+                    return True
+                else:
+                    lgr.debug(
+                        "There is no annexurl defined but not ssh: %s, "
+                        "dunno if "
+                        "we could/should do anything", remote_annexurl
+                    )
+    return False
+
+
+def _maybe_fetch(repo, remote):
+    if repo.config.get("remote.{}.fetch".format(remote)):
+        repo.fetch(remote=remote, recurse_submodules="no")
+    else:
+        # Fetching would lead to "Couldn't find remote ref HEAD" if no
+        # branch" error.  See gh-4199 for an example.
+        lgr.warning("Remote %s has no configured refspec", remote)
+
+
+def _publish_dataset(ds, remote, refspec, paths, annex_copy_options, force=False, jobs=None,
+                     transfer_data='auto', **kwargs):
+    remote_branch_name = _get_remote_branch(ds, refspec)
+    if not remote_branch_name:
+        yield get_status_dict(
+            ds=ds,
+            status='impossible',
+            message=(
+                'Cannot determine remote branch name from %s',
+                'HEAD' if not refspec else refspec,
+            ),
+            **kwargs)
+        return
+    # TODO: this setup is now quite ugly. The only way `refspec` can come
+    # in, is when there is a tracking branch, and we get its state via
+    # `refspec`
+
+    # define config var name for potential publication dependencies
+    depvar = 'remote.{}.datalad-publish-depends'.format(remote)
+    # list of remotes that are publication dependencies for the
+    # target remote
+    publish_depends = ensure_list(ds.config.get(depvar, []))
+
+    # remote might be set to be ignored by annex, or we might not even know yet its uuid
+    # make sure we are up-to-date on this topic on all affected remotes, before
+    # we start making decisions
+    for r in publish_depends + [remote]:
+        if not ds.config.get('.'.join(('remote', r, 'annex-uuid')), None):
+            lgr.debug("Obtain remote annex info from '%s'", r)
+            _maybe_fetch(ds.repo, r)
+            # in order to be able to use git's config to determine what to push,
+            # we need to annex merge first. Otherwise a git push might be
+            # rejected if involving all matching branches for example.
+            # NOTE we should not use a precomputed 'is_annex' test here, as
+            # each fetch could give evidence that there is an annex
+            # somewhere and replace the repo class...
+            if isinstance(ds.repo, AnnexRepo):
+                ds.repo.localsync(r)
+    ds.config.reload()
+
+    # anything that follows will not change the repo type anymore, cache
+    is_annex_repo = isinstance(ds.repo, AnnexRepo)
+
+    # Plan:
+    # 1. Check if there is anything to push, and if so
+    #    2. process push dependencies
+    #    3. fetch and merge annex branch
+    #    4. push non-annex branch(es)
+    # 5. copy data to the remote if paths are provided or it wants something generally
+
+    # upstream refspec needed for update (merge) and subsequent push,
+    # in case there is no.
+    # no tracking refspec yet?
+
+    # TODO: i think this whole modification detection could be done by path
+    # annotation at the very beginning -- keeping it for now to not get too
+    # dizzy in the forehead....
+
+    # if forced -- we push regardless if there are differences or not
+    diff = True if force else has_diff(ds, remote_branch_name, remote, paths)
+
+    # We might have got new information in git-annex branch although no other
+    # changes
+    if not diff and is_annex_repo:
+        try:
+            git_annex_commit = next(ds.repo.get_branch_commits_('git-annex'))
+        except StopIteration:
+            git_annex_commit = None
+        #diff = _get_remote_diff(ds, [], git_annex_commit, remote, 'git-annex')
+        diff = _get_remote_diff(ds.repo, git_annex_commit, remote, 'git-annex')
+        if diff:
+            lgr.info("Will publish updated git-annex")
+
+    #
+    # publish data (annex copy --to)
+    #
+    # # remote might be set to be ignored by annex, or we might not even know yet its uuid
+    # annex_ignore = ds.config.getbool('remote.{}.annex-ignore'.format(remote), None)
+    # annex_uuid = ds.config.get('remote.{}.annex-uuid'.format(remote), None)
+    # if not annex_ignore:
+    #     if annex_uuid is None:
+    #         # most probably not yet 'known' and might require some annex
+
+    copied_data = False
+    # skip right away if data transfer is not desired
+    if transfer_data != 'none' and isinstance(ds.repo, AnnexRepo):
+        # publishing of `remote` might depend on publishing other
+        # remote(s) first, so they need to receive the data first:
+        for d, desc in [
+            (d, "configured publication dependency")
+            for d in publish_depends
+        ] + [
+            # no message the target remote as before
+            (remote, None)
+        ]:
+            if desc:
+                lgr.info("Transferring data to %s: '%s'", desc, d)
+            # properly initialized remote annex -> publish data
+            for r in _publish_data(
+                    ds,
+                    d,
+                    paths,
+                    annex_copy_options,
+                    force,
+                    transfer_data,
+                    **kwargs):
+                # note if we published any data, notify to sync annex branch below
+                if r['status'] == 'ok' and r['action'] == 'publish' and \
+                        r.get('type', None) == 'file':
+                    copied_data = True
+                yield r
+
+    #
+    # publish dataset (git push)
+    #
+    if not diff and not copied_data:
+        lgr.debug("No changes detected with respect to state of '%s'", remote)
+        yield get_status_dict(ds=ds, status='notneeded', **kwargs)
+    else:
+        # publishing of `remote` might depend on publishing other
+        # remote(s) first:
+        for d in publish_depends:
+            lgr.info("Publishing to configured dependency: '%s'", d)
+            # call this again to take care of the dependency first,
+            # but keep the paths the same, as the goal is to publish those
+            # to the primary remote, and not anything elase to a dependency
+            for r in _publish_dataset(
+                    ds,
+                    d,
+                    # should get the same as the base dataset
+                    refspec,
+                    paths,
+                    annex_copy_options,
+                    force=force,
+                    jobs=jobs,
+                    transfer_data=transfer_data,
+                    **kwargs):
+                yield r
+
+        if is_annex_repo and \
+                ds.repo.is_special_annex_remote(remote):
+            # There is nothing else to "publish"
+            lgr.debug(
+                "{0} is a special annex remote, no git push is needed".format(remote)
+            )
+            return
+
+        lgr.info("Publishing {0} to {1}".format(ds, remote))
+        # in order to be able to use git's config to determine what to push,
+        # we need to annex merge first. Otherwise a git push might be
+        # rejected if involving all matching branches for example
+        # even if we already fetched above we need to do it again
+        if is_annex_repo:
+            lgr.debug("Obtain remote annex info from '%s'", remote)
+            _maybe_fetch(ds.repo, remote)
+            ds.repo.localsync(remote)
+
+        # Note: git's push.default is 'matching', which doesn't work for first
+        # time publication (a branch, that doesn't exist on remote yet)
+        # But if we want to respect remote.*.push entries, etc. we need to
+        # not pass a specific refspec (like active branch) to `git push`
+        # by default.
+        # hence we amend any existing config on the fly
+        # TODO: what else to push by default?
+        # consider also: --follow-tags, --tags, --atomic
+        # make sure we push
+        things2push = []
+        current_branch = ds.repo.get_active_branch()
+        if current_branch:  # possibly make this conditional on a switch
+            # TODO: this should become it own helper
+            if is_annex_repo:
+                # annex could manage this branch
+                match_adjusted = re.match(
+                    r'adjusted/(.*)\([a-z]*\)',
+                    current_branch)
+                if match_adjusted:
+                    # adjusted/master(...)
+                    # TODO:  this code is not tested
+                    # see https://codecov.io/gh/datalad/datalad/src/17e67045a088ae0372b38aa4d8d46ecf7c821cb7/datalad/distribution/publish.py#L156
+                    # and thus probably broken -- test me!
+                    current_branch = match_adjusted.group(1)
+            things2push.append(current_branch)
+        if is_annex_repo:
+            things2push.append('git-annex')
+        # check that all our magic found valid branches
+        things2push = [t for t in things2push if t in ds.repo.get_branches()]
+        # check that we don't ask to push things that are already configured
+        # -> would cause error
+        # TODO need to find a way to properly do this, when wildcards are used
+        # in the push configuration variable
+        things2push = [t for t in things2push
+                       if t not in ds.config.get('remote.{}.push'.format(remote), [])]
+        # now we know what to push where
+        status, msg = _push(ds, remote, things2push, force)
+        yield get_status_dict(ds=ds, status=status, message=msg, **kwargs)
+
+
+def _get_remote_info(ds_path, ds_remote_info, to, missing):
+    """Returns None if desired info was obtained, or a tuple (status, message)
+    if not"""
+    ds = Dataset(ds_path)
+    if ds.repo is None:
+        # There is no repository, nothing could be done
+        return ('impossible',
+                'No repository found for %s' % ds)
+    if to is None:
+        # we need an upstream remote, if there's none given. We could
+        # wait for git push to complain, but we need to explicitly
+        # figure it out for pushing annex branch anyway and we might as
+        # well fail right here.
+        track_remote, track_refspec = ds.repo.get_tracking_branch()
+        if not track_remote:
+            # no tracking remote configured, but let try one more
+            # if we only have one remote, and it has a push target
+            # configured that is "good enough" for us
+            cand_remotes = [r for r in ds.repo.get_remotes()
+                            if 'remote.{}.push'.format(r) in ds.config]
+            if len(cand_remotes) > 1:
+                lgr.warning('Target sibling ambiguous, please specify via --to')
+            elif len(cand_remotes) == 1:
+                track_remote = cand_remotes[0]
+            else:
+                return ('impossible',
+                        'No target sibling configured for default publication, '
+                        'please specify via --to')
+        if track_remote:
+            ds_remote_info[ds_path] = dict(zip(
+                ('remote', 'refspec'),
+                (track_remote, track_refspec)))
+        elif missing == 'skip':
+            ds_remote_info[ds_path] = None
+            return ('notneeded',
+                    'Cannot determine target sibling, skipping publication')
+        else:
+            # we have no remote given and no upstream
+            return 'error', 'Cannot determine a default target sibling for publication'
+    elif to not in ds.repo.get_remotes():
+        # unknown given remote
+        if missing == 'skip':
+            ds_remote_info[ds_path] = None
+            return ('notneeded',
+                    ("Unknown target sibling '%s', skipping publication", to))
+        elif missing == 'inherit':
+            superds = ds.get_superdataset()
+            if not superds:
+                return ('error',
+                        ("No super-dataset to inherit settings for remote %s", to))
+            # XXX due to difference between create-sibling and create-sibling-github
+            # would not be as transparent to inherit for -github
+            lgr.info("Will try to create a sibling inheriting settings from %s", superds)
+            # XXX explicit None as sshurl for now
+            # TODO this is not good: e.g. #1344
+            ds.create_sibling(None, name=to, inherit=True)
+            ds_remote_info[ds_path] = {'remote': to}
+        else:
+            return ('error',
+                    ("Unknown target sibling '%s' for publication", to))
+    else:
+        # all good: remote given and is known
+        ds_remote_info[ds_path] = {'remote': to}
+
+
+def _get_remote_diff(repo, current_commit, remote, remote_branch_name):
+    """Helper to check if remote has different state of the branch"""
+    remote_ref = '/'.join((remote, remote_branch_name))
+    if remote_ref in repo.get_remote_branches():
+        lgr.debug("Testing for changes with respect to '%s' of remote '%s'",
+                  remote_branch_name, remote)
+        if current_commit is None:
+            current_commit = repo.get_hexsha()
+        remote_ref = repo.get_hexsha(remote_ref)
+        diff = current_commit != remote_ref
+    else:
+        lgr.debug("Remote '%s' has no branch matching %r. Will publish",
+                  remote, remote_branch_name)
+        # we don't have any remote state, need to push for sure
+        diff = True
+
+    return diff
+
+
+@build_doc
+class Publish(Interface):
+    """Publish a dataset to a known :term:`sibling`.
+
+    This makes the last saved state of a dataset available to a sibling
+    or special remote data store of a dataset. Any target sibling must already
+    exist and be known to the dataset.
+
+    Optionally, it is possible to limit publication to change sets relative
+    to a particular point in the version history of a dataset (e.g. a release
+    tag). By default, the state of the local dataset is evaluated against the
+    last known state of the target sibling. Actual publication is only attempted
+    if there was a change compared to the reference state, in order to speed up
+    processing of large collections of datasets. Evaluation with respect to
+    a particular "historic" state is only supported in conjunction with a
+    specified reference dataset. Change sets are also evaluated recursively, i.e.
+    only those subdatasets are published where a change was recorded that is
+    reflected in to current state of the top-level reference dataset.
+    See "since" option for more information.
+
+    Only publication of saved changes is supported. Any unsaved changes in a
+    dataset (hierarchy) have to be saved before publication.
+
+    .. note::
+      Power-user info: This command uses :command:`git push`, and :command:`git annex copy`
+      to publish a dataset. Publication targets are either configured remote
+      Git repositories, or git-annex special remotes (if they support data
+      upload).
+
+    .. note::
+      This command is deprecated. It will be removed from DataLad eventually,
+      but no earlier than the 0.15 release. The `push` command (new in 0.13.0)
+      provides an alternative interface. Critical differences are that `push`
+      transfers annexed data by default and does not handle sibling creation
+      (i.e. it does not have a `--missing` option).
+    """
+    # TODO: Figure out, how to tell about tracking branch/upstream
+    #      (and the respective remote)
+    #      - it is used, when no destination is given
+    #      - it is configured to be the given destination, if there was no
+    #        upstream set up before, so you can use just "datalad publish" next
+    #        time.
+
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            metavar='DATASET',
+            doc="""specify the (top-level) dataset to be published. If no dataset
+            is given, the datasets are determined based on the input arguments""",
+            constraints=EnsureDataset() | EnsureNone()),
+        to=Parameter(
+            args=("--to",),
+            metavar='LABEL',
+            doc="""name of the target sibling. If no name is given an attempt is
+            made to identify the target based on the dataset's configuration
+            (i.e. a configured tracking branch, or a single sibling that is
+            configured for publication)""",
+            # TODO: See TODO at top of class!
+            constraints=EnsureStr() | EnsureNone()),
+        since=Parameter(
+            args=("--since",),
+            constraints=EnsureStr() | EnsureNone(),
+            doc="""specifies commit-ish (tag, shasum, etc.) from which to look for
+            changes to decide whether pushing is necessary.
+            If '^' is given, the last state of the current branch at the sibling
+            is taken as a starting point. An empty string ('') for the same effect is
+            still supported)."""),
+        # since: commit => .gitmodules diff to head => submodules to publish
+        missing=missing_sibling_opt,
+        path=Parameter(
+            args=("path",),
+            metavar='PATH',
+            # TODO this description is no longer correct
+            doc="path(s), that may point to file handle(s) to publish including "
+                "their actual content or to subdataset(s) to be published. If a "
+                "file handle is published with its data, this implicitly means "
+                "to also publish the (sub)dataset it belongs to. '.' as a path "
+                "is treated in a special way in the sense, that it is passed "
+                "to subdatasets in case `recursive` is also given.",
+            constraints=EnsureStr() | EnsureNone(),
+            nargs='*'),
+        force=Parameter(
+            args=("-f", "--force",),
+            doc="""enforce doing publish activities (git push etc) regardless of
+            the analysis if they seemed needed""",
+            action='store_true'),
+        # TODO add option to decide what branch/repo to push
+        transfer_data=Parameter(
+            args=("--transfer-data",),
+            doc="""ADDME""",
+            constraints=EnsureChoice('auto', 'none', 'all')),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+        git_opts=git_opts,
+        annex_opts=annex_opts,
+        annex_copy_opts=annex_copy_opts,
+        jobs=jobs_opt,
+    )
+
+    @staticmethod
+    @datasetmethod(name='publish')
+    @eval_results
+    def __call__(
+            path=None,
+            dataset=None,
+            to=None,
+            since=None,
+            missing='fail',
+            force=False,
+            transfer_data='auto',
+            recursive=False,
+            recursion_limit=None,
+            git_opts=None,
+            annex_opts=None,
+            annex_copy_opts=None,
+            jobs=None
+    ):
+
+        import warnings
+        warnings.warn("`publish` is deprecated. Use `datalad push` instead.",
+                      DeprecationWarning)
+
+        # if ever we get a mode, for "with-data" we would need this
+        #if dataset and not path:
+        #    # act on the whole dataset if nothing else was specified
+        #    path = dataset.path if isinstance(dataset, Dataset) else dataset
+
+        if not (isinstance(dataset, Dataset) or (dataset is None and path)):
+            # try to find a dataset in PWD
+            dataset = require_dataset(
+                dataset, check_installed=True, purpose='publish')
+
+        if (since and since != '^') and not dataset:
+            raise InsufficientArgumentsError(
+                'Modification detection (--since) without a base dataset '
+                'is not supported')
+
+        if dataset and since in ('', '^'):
+            # only update since last update so we figure out what was the last update
+            active_branch = dataset.repo.get_active_branch()
+            if to:
+                # XXX here we assume one to one mapping of names from local branches
+                # to the remote
+                since = '%s/%s' % (to, active_branch)
+                # test if such branch already exists,
+                if since not in dataset.repo.get_remote_branches():
+                    lgr.debug("No remote branch %s yet, so since will not be used", since)
+                    since = None
+            else:
+                # take tracking remote for the active branch
+                tracked_remote, tracked_refspec = dataset.repo.get_tracking_branch()
+                if tracked_remote:
+                    if tracked_refspec.startswith('refs/heads/'):
+                        tracked_refspec = tracked_refspec[len('refs/heads/'):]
+                    #to = tracked_remote
+                    since = '%s/%s' % (tracked_remote, tracked_refspec)
+                else:
+                    lgr.info(
+                        "No tracked remote for %s. since option is of no effect",
+                        active_branch
+                    )
+                    since = None
+
+        # here is the plan
+        # 1. figure out remote to publish to
+        # 2. figure out which content needs to be published to this remote
+        # 3. look for any pre-publication dependencies of that remote
+        #    (i.e. remotes that need to be published to before)
+        # 4. publish the content needed to go to the primary remote to
+        #    the dependencies first, and to the primary afterwards
+        ds_remote_info = {}
+
+        refds_path = Interface.get_refds_path(dataset)
+        res_kwargs = dict(refds=refds_path, logger=lgr, action='publish')
+
+        to_process = []
+        for ap in AnnotatePaths.__call__(
+                dataset=refds_path,
+                path=path,
+                recursive=recursive,
+                recursion_limit=recursion_limit,
+                action='publish',
+                unavailable_path_status='impossible',
+                nondataset_path_status='error',
+                modified="%s..HEAD" % since if since else since,
+                return_type='generator',
+                on_failure='ignore',
+                force_no_revision_change_discovery=False, # we cannot publish what was not committed
+                force_untracked_discovery=False  # we cannot publish untracked
+        ):
+            if ap.get('status', None):
+                # this is done
+                yield ap
+                continue
+            remote_info_result = None
+            if ap.get('type', ap.get('type_src', 'dataset')) != 'dataset':
+                # for everything that is not a dataset get the remote info
+                # for the parent
+                parentds = ap.get('parentds', None)
+                if parentds and parentds not in ds_remote_info:
+                    remote_info_result = _get_remote_info(
+                        parentds, ds_remote_info, to, missing)
+            else:
+                # this is a dataset
+                if ap.get('state', None) == 'absent':
+                    continue
+                # get the remote info for itself
+                remote_info_result = _get_remote_info(
+                    ap['path'], ds_remote_info, to, missing)
+                ap['process_content'] = True
+            if remote_info_result is not None:
+                ap['status'] = remote_info_result[0]
+                ap['message'] = remote_info_result[1]
+                yield ap
+                continue
+            to_process.append(ap)
+
+        content_by_ds, ds_props, completed, nondataset_paths = \
+            annotated2content_by_ds(
+                to_process,
+                refds_path=refds_path)
+        assert(not completed)
+
+        lgr.debug(
+            "Evaluating %i dataset publication candidate(s)",
+            len(content_by_ds))
+        # TODO: fancier sorting, so we still follow somewhat the hierarchy
+        #       in sorted order, e.g.
+        #  d1/sub1/sub1
+        #  d1/sub1
+        #  d1
+        #  d2/sub1
+        #  d2
+        content_by_ds = OrderedDict(
+            (d, content_by_ds[d]) for d in sorted(content_by_ds, reverse=True)
+        )
+
+        lgr.debug("Attempt to publish %i datasets", len(content_by_ds))
+        for ds_path in content_by_ds:
+            remote_info = ds_remote_info.get(ds_path, None)
+            if remote_info is None:
+                # maybe this dataset wasn't annotated above, try to get info
+                # MIH: I think this entire if-branch is practically impossible
+                # to reach. It is certainly untested, but I think this is due
+                # to mutually exclusive conditions during remote_info detection
+                remote_info_result = _get_remote_info(
+                    ds_path, ds_remote_info, to, missing)
+                if remote_info_result is not None:
+                    yield get_status_dict(
+                        type='dataset',
+                        path=ds_path,
+                        status=remote_info_result[0],
+                        message=remote_info_result[1],
+                        **res_kwargs)
+                    continue
+                # continue with freshly obtained info
+                remote_info = ds_remote_info[ds_path]
+                # condition above must catch all other cases
+                assert remote_info
+            # and publish
+            ds = Dataset(ds_path)
+            for r in _publish_dataset(
+                    ds,
+                    remote=remote_info['remote'],
+                    refspec=remote_info.get('refspec', None),
+                    # only send paths that were explicitly requested
+                    paths=[p for p in content_by_ds[ds_path]
+                           # do not feed (sub)dataset paths into the beast
+                           # makes no sense to try to annex copy them
+                           # for the base dataset itself let `transfer_data`
+                           # decide
+                           if p.get('type', None) != 'dataset'],
+                    annex_copy_options=annex_copy_opts,
+                    force=force,
+                    jobs=jobs,
+                    transfer_data=transfer_data,
+                    **res_kwargs):
+                yield r

--- a/datalad_deprecated/publish.py
+++ b/datalad_deprecated/publish.py
@@ -48,10 +48,12 @@ from datalad.support.network import (
 
 from datalad.utils import ensure_list
 
-from .dataset import EnsureDataset
-from .dataset import Dataset
-from .dataset import datasetmethod
-from .dataset import require_dataset
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    Dataset,
+    datasetmethod,
+    require_dataset,
+)
 
 __docformat__ = 'restructuredtext'
 

--- a/datalad_deprecated/tests/test_publish.py
+++ b/datalad_deprecated/tests/test_publish.py
@@ -65,6 +65,10 @@ from datalad.tests.utils import (
     with_tree,
 )
 
+# we are running this test from -core, which is mostly about create_sibling
+# but requires publish()
+from datalad.distribution.tests.test_create_sibling import test_target_ssh_inherit
+
 
 def filter_fsck_error_msg(dicts):
     # Filter keys that have expected differences when comparing target.fsck()

--- a/datalad_deprecated/tests/test_publish.py
+++ b/datalad_deprecated/tests/test_publish.py
@@ -1,0 +1,788 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test publish action
+
+"""
+
+import logging
+from os.path import (
+    exists,
+    join as opj,
+    lexists,
+)
+from ..dataset import Dataset
+from datalad.api import (
+    create,
+    install,
+    publish,
+)
+from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import (
+    IncompleteResultsError,
+    InsufficientArgumentsError,
+)
+from datalad.utils import (
+    chpwd,
+    Path,
+    _path_,
+)
+from datalad.cmd import GitWitlessRunner
+from datalad.tests.utils import (
+    assert_false as nok_,
+    assert_false,
+    assert_in,
+    assert_not_equal,
+    assert_not_in,
+    assert_raises,
+    assert_repo_status,
+    assert_result_count,
+    assert_status,
+    create_tree,
+    DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
+    eq_,
+    known_failure_windows,
+    neq_,
+    ok_,
+    ok_file_has_content,
+    serve_path_via_http,
+    skip_if_on_windows,
+    skip_ssh,
+    slow,
+    swallow_logs,
+    with_tempfile,
+    with_testrepos,
+    with_tree,
+)
+
+
+def filter_fsck_error_msg(dicts):
+    # Filter keys that have expected differences when comparing target.fsck()
+    # to fsck(remote=target).
+    return [{k: v for k, v in d.items() if k not in ["error-messages", "note"]}
+            for d in dicts]
+
+
+@with_testrepos('submodule_annex', flavors=['local'])
+@with_tempfile(mkdir=True)
+def test_invalid_call(origin, tdir):
+    ds = Dataset(origin)
+    ds.uninstall('subm 1', check=False)
+    # nothing
+    assert_status('error', publish('/notthere', on_failure='ignore'))
+    # known, but not present
+    assert_status('impossible', publish(opj(ds.path, 'subm 1'), on_failure='ignore'))
+    # --since without dataset is now supported as long as it
+    # could be identified
+    # assert_raises(InsufficientArgumentsError, publish, since='HEAD')
+    # but if it couldn't be, then should indeed crash
+    with chpwd(tdir):
+        assert_raises(InsufficientArgumentsError, publish, since='HEAD')
+    # new dataset, with unavailable subdataset
+    dummy = Dataset(tdir).create()
+    dummy_sub = dummy.create('sub')
+    dummy_sub.uninstall()
+    assert_in('sub', dummy.subdatasets(fulfilled=False, result_xfm='relpaths'))
+    # now an explicit call to publish the unavailable subdataset
+    assert_result_count(
+        dummy.publish('sub', on_failure='ignore'),
+        1,
+        path=dummy_sub.path,
+        status='impossible',
+        type='dataset')
+
+
+@known_failure_windows
+@with_tempfile
+@with_tempfile
+def test_since_empty_and_unsupported(p1, p2):
+    source = Dataset(p1).create()
+    source.create_sibling(p2, name='target1')
+    # see https://github.com/datalad/datalad/pull/4448#issuecomment-620847327
+    # Test that it doesn't fail without a prior push
+    source.publish(to='target1', since='')
+    with chpwd(p1):
+        # since we have only two commits (set backend, init dataset)
+        # -- there is no HEAD^^
+        assert_result_count(
+            publish(to='target1', since='HEAD^^', on_failure='ignore'),
+            1,
+            status='impossible',
+            message="fatal: bad revision 'HEAD^^..HEAD'")
+        # but now let's add one more commit, we should be able to pusblish
+        source.repo.commit("msg", options=['--allow-empty'])
+        publish(to='target1', since='HEAD^')  # must not fail now
+
+
+def assert_git_annex_branch_published(source, target):
+    """Check that tip of git-annex branch in `source` is in `target`.
+
+    Parameters
+    ----------
+    source, target : *Repo instances
+    """
+    # Note: This helper avoids assuming that the tip of the git-annex
+    # branch on the target matches the source repo's. The remote could
+    # have an extra commit if, for example, initialization was
+    # triggered due to a post-receive hook (gh-1319) or
+    # auto-initialization (for git-annex versions newer than
+    # 8.20200522).
+    source_commit = source.get_hexsha("git-annex")
+    if not target.is_ancestor(source_commit, "git-annex"):
+        raise AssertionError(
+            "Tip of source repo's git-annex branch not in target repo's\n"
+            "  source commit, location: {}, {}\n"
+            "  target commit, location: {}, {}"
+            .format(source_commit, source.path,
+                    target.get_hexsha("git-annex"), target.path))
+
+
+@with_tempfile(mkdir=True)
+def test_assert_git_annex_branch_published(path):
+    repo_a = AnnexRepo(opj(path, "a"), create=True)
+    repo_b = AnnexRepo(opj(path, "b"), create=True)
+    with assert_raises(AssertionError):
+        assert_git_annex_branch_published(repo_a, repo_b)
+
+
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:571
+@known_failure_windows
+@with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_publish_simple(origin, src_path, dst_path):
+
+    # prepare src
+    source = install(src_path, source=origin, recursive=True)
+    # forget we cloned it by removing remote, which should lead to
+    # setting tracking branch to target:
+    source.repo.remove_remote(DEFAULT_REMOTE)
+
+    # create plain git at target:
+    target = GitRepo(dst_path, create=True)
+    target.checkout("TMP", ["-b"])
+    source.repo.add_remote("target", dst_path)
+
+    res = publish(dataset=source, to="target", result_xfm='datasets')
+    eq_(res, [source])
+
+    assert_repo_status(source.repo, annex=None)
+    assert_repo_status(target, annex=None)
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+
+    # don't fail when doing it again
+    res = publish(dataset=source, to="target")
+    # and nothing is pushed
+    assert_result_count(res, 1, status='notneeded')
+
+    assert_repo_status(source.repo, annex=None)
+    assert_repo_status(target, annex=None)
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+    assert_git_annex_branch_published(source.repo, target)
+
+    # 'target/<default branch>' should be tracking branch at this point, so
+    # try publishing without `to`:
+    # MIH: Nope, we don't automatically add this anymore
+
+    # some modification:
+    with open(opj(src_path, 'test_mod_file'), "w") as f:
+        f.write("Some additional stuff.")
+    source.save(opj(src_path, 'test_mod_file'), to_git=True,
+                message="Modified.")
+    assert_repo_status(source.repo, annex=None)
+
+    res = publish(dataset=source, to='target', result_xfm='datasets')
+    eq_(res, [source])
+
+    assert_repo_status(dst_path, annex=None)
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+    assert_git_annex_branch_published(source.repo, target)
+
+    eq_(filter_fsck_error_msg(source.repo.fsck()),
+        filter_fsck_error_msg(source.repo.fsck(remote='target')))
+
+
+@with_testrepos('basic_git', flavors=['local'])
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_publish_plain_git(origin, src_path, dst_path):
+    # TODO: Since it's mostly the same, melt with test_publish_simple
+
+    # prepare src
+    source = install(src_path, source=origin, recursive=True)
+    # forget we cloned it by removing remote, which should lead to
+    # setting tracking branch to target:
+    source.repo.remove_remote(DEFAULT_REMOTE)
+
+    # create plain git at target:
+    target = GitRepo(dst_path, create=True)
+    target.checkout("TMP", ["-b"])
+    source.repo.add_remote("target", dst_path)
+
+    res = publish(dataset=source, to="target", result_xfm='datasets')
+    eq_(res, [source])
+
+    assert_repo_status(source.repo, annex=None)
+    assert_repo_status(target, annex=None)
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+
+    # don't fail when doing it again
+    res = publish(dataset=source, to="target")
+    # and nothing is pushed
+    assert_result_count(res, 1, status='notneeded')
+
+    assert_repo_status(source.repo, annex=None)
+    assert_repo_status(target, annex=None)
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+
+    # some modification:
+    with open(opj(src_path, 'test_mod_file'), "w") as f:
+        f.write("Some additional stuff.")
+    source.save(opj(src_path, 'test_mod_file'), to_git=True,
+               message="Modified.")
+    assert_repo_status(source.repo, annex=None)
+
+    res = publish(dataset=source, to='target', result_xfm='datasets')
+    eq_(res, [source])
+
+    assert_repo_status(dst_path, annex=None)
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+
+    # amend and change commit msg in order to test for force push:
+    source.repo.commit("amended", options=['--amend'])
+    # push should be rejected (non-fast-forward):
+    assert_raises(IncompleteResultsError,
+                  publish, dataset=source, to='target', result_xfm='datasets')
+    # push with force=True works:
+    res = publish(dataset=source, to='target', result_xfm='datasets', force=True)
+    eq_(res, [source])
+
+
+@slow  # 12sec on travis
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:380
+@known_failure_windows
+@with_testrepos('submodule_annex', flavors=['local'])
+@with_tempfile
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_publish_recursive(pristine_origin, origin_path, src_path, dst_path, sub1_pub, sub2_pub):
+
+    # we will be publishing back to origin, so to not alter testrepo
+    # we will first clone it
+    origin = install(origin_path, source=pristine_origin, recursive=True)
+    # uncouple subdataset from testrepo sources after recursive install
+    # to make this clone the source of all `get` attempts
+    for sub in origin.subdatasets(result_xfm=lambda x: x['gitmodule_name']):
+        origin.subdatasets(path=sub, set_property=[('url', './{}'.format(sub))])
+    # prepare src
+    source = install(src_path, source=origin.path, recursive=True)
+    # we will be trying to push into this later on, need to give permissions...
+    origin_sub2 = Dataset(opj(origin_path, '2'))
+    origin_sub2.config.set(
+        'receive.denyCurrentBranch', 'updateInstead', where='local')
+    ## TODO this manual fixup is needed due to gh-1548 -- needs proper solution
+    #os.remove(opj(origin_sub2.path, '.git'))
+    #os.rename(opj(origin_path, '.git', 'modules', '2'), opj(origin_sub2.path, '.git'))
+
+    # create plain git at target:
+    target = GitRepo(dst_path, create=True)
+    target.checkout("TMP", ["-b"])
+    source.repo.add_remote("target", dst_path)
+
+    # subdatasets have no remote yet, so recursive publishing should fail:
+    res = publish(dataset=source, to="target", recursive=True, on_failure='ignore')
+    assert_result_count(res, 3)
+    assert_result_count(
+        res, 1, status='ok', type='dataset', path=source.path)
+    assert_result_count(
+        res, 2, status='error',
+        message=("Unknown target sibling '%s' for publication", 'target'))
+
+    # now, set up targets for the submodules:
+    sub1_target = GitRepo(sub1_pub, create=True)
+    sub1_target.checkout("TMP", ["-b"])
+    sub2_target = AnnexRepo(sub2_pub, create=True)
+    # we will be testing presence of the file content, so let's make it progress
+    sub2_target.config.set('receive.denyCurrentBranch', 'updateInstead', where='local')
+    sub1 = GitRepo(opj(src_path, 'subm 1'), create=False)
+    sub2 = GitRepo(opj(src_path, '2'), create=False)
+    sub1.add_remote("target", sub1_pub)
+    sub2.add_remote("target", sub2_pub)
+
+    # publish recursively
+    with swallow_logs(new_level=logging.DEBUG) as cml:
+        res = publish(dataset=source, to="target", recursive=True)
+        assert_not_in(
+            'forced update', cml.out,
+            "we probably haven't merged git-annex before pushing"
+        )
+
+    # testing result list
+    # base dataset was already published above, notneeded again
+    assert_status(('ok', 'notneeded'), res)  # nothing failed
+    assert_result_count(
+        res, 3, type='dataset')
+    eq_({r['path'] for r in res},
+        {src_path, sub1.path, sub2.path})
+
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+    assert_git_annex_branch_published(source.repo, target)
+    eq_(list(sub1_target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(sub1.get_branch_commits_(DEFAULT_BRANCH)))
+    assert_git_annex_branch_published(sub1, sub1_target)
+    eq_(list(sub2_target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(sub2.get_branch_commits_(DEFAULT_BRANCH)))
+    assert_git_annex_branch_published(sub2, sub2_target)
+
+    # we are tracking origin but origin has different git-annex, since we
+    # cloned from it, so it is not aware of our git-annex
+    neq_(list(origin.repo.get_branch_commits_("git-annex")),
+         list(source.repo.get_branch_commits_("git-annex")))
+    # So if we first publish to it recursively, we would update
+    # all sub-datasets since git-annex branch would need to be pushed
+    res_ = publish(dataset=source, recursive=True)
+    assert_result_count(res_, 1, status='ok', path=source.path)
+    assert_result_count(res_, 1, status='ok', path=sub1.path)
+    assert_result_count(res_, 1, status='ok', path=sub2.path)
+    # and now should carry the same state for git-annex
+    assert_git_annex_branch_published(source.repo, origin.repo)
+
+    # test for publishing with  --since.  By default since no changes, nothing pushed
+    res_ = publish(dataset=source, recursive=True)
+    assert_result_count(
+        res_, 3, status='notneeded', type='dataset')
+
+    # still nothing gets pushed, because origin is up to date
+    res_ = publish(dataset=source, recursive=True, since='HEAD^')
+    assert_status('notneeded', res_)
+
+    # and we should not fail if we run it from within the dataset
+    with chpwd(source.path):
+        res_ = publish(recursive=True, since='HEAD^')
+        assert_status('notneeded', res_)
+
+    # Let's now update one subm
+    with open(opj(sub2.path, "file.txt"), 'w') as f:
+        f.write('')
+    # add to subdataset, does not alter super dataset!
+    # MIH: use `to_git` because original test author used
+    # and explicit `GitRepo.add` -- keeping this for now
+    Dataset(sub2.path).save('file.txt', to_git=True)
+
+    # Let's now update one subm
+    create_tree(sub2.path, {'file.dat': 'content'})
+    # add to subdataset, without reflecting the change in its super(s)
+    Dataset(sub2.path).save('file.dat')
+
+    # note: will publish to origin here since that is what it tracks
+    res_ = publish(dataset=source, recursive=True, on_failure='ignore')
+    ## only updates published, i.e. just the subdataset, super wasn't altered
+    ## nothing copied!
+    assert_status(('ok', 'notneeded'), res_)
+    assert_result_count(res_, 1, status='ok', path=sub2.path, type='dataset')
+    assert_result_count(res_, 0, path=opj(sub2.path, 'file.dat'), type='file')
+
+    # since published to origin -- destination should not get that file
+    nok_(lexists(opj(sub2_target.path, 'file.dat')))
+    res_ = publish(dataset=source, to='target', recursive=True)
+    assert_status(('ok', 'notneeded'), res_)
+    assert_result_count(res_, 1, status='ok', path=sub2.path, type='dataset')
+    assert_result_count(res_, 0, path=opj(sub2.path, 'file.dat'), type='file')
+
+    # Note: with updateInstead only in target2 and not saving change in
+    # super-dataset we would have made remote dataset, if we had entire
+    # hierarchy, to be somewhat inconsistent.
+    # But here, since target datasets are independent -- it is ok
+
+    # and the file itself was transferred
+    ok_(lexists(opj(sub2_target.path, 'file.dat')))
+    nok_(sub2_target.file_has_content('file.dat'))
+
+    ## but now we can redo publish recursively, with explicitly requested data transfer
+    res_ = publish(
+        dataset=source, to='target',
+        recursive=True,
+        transfer_data='all'
+    )
+    ok_(sub2_target.file_has_content('file.dat'))
+    assert_result_count(
+        res_, 1, status='ok', path=opj(sub2.path, 'file.dat'))
+
+    # Let's save those present changes and publish while implying "since last
+    # merge point"
+    source.save(message="Changes in subm2")
+    # and test if it could deduce the remote/branch to push to
+    source.config.set('branch.{}.remote'.format(DEFAULT_BRANCH),
+                      'target', where='local')
+    with chpwd(source.path):
+        res_ = publish(since='^', recursive=True)
+    # TODO: somehow test that there were no even attempt to diff within "subm 1"
+    # since if `--since=''` worked correctly, nothing has changed there and it
+    # should have not been even touched
+    assert_status(('ok', 'notneeded'), res_)
+    assert_result_count(res_, 1, status='ok', path=source.path, type='dataset')
+
+    # Don't fail when a string is passed as `dataset` and since="".
+    assert_status("notneeded", publish(since='^', dataset=source.path))
+
+
+# https://github.com/datalad/datalad/pull/3975/checks?check_run_id=369789022#step:8:452
+@slow  # 10sec on Yarik's laptop
+@known_failure_windows
+@with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+@with_tempfile
+def test_publish_with_data(origin, src_path, dst_path, sub1_pub, sub2_pub, dst_clone_path):
+
+    # prepare src
+    source = install(src_path, source=origin, recursive=True)
+    source.repo.get('test-annex.dat')
+
+    # create plain git at target:
+    target = AnnexRepo(dst_path, create=True)
+    target.checkout("TMP", ["-b"])
+    source.repo.add_remote("target", dst_path)
+
+    # now, set up targets for the submodules:
+    # the need to be annexes, because we want to be able to copy data to them
+    # further down
+    sub1_target = AnnexRepo(sub1_pub, create=True)
+    sub1_target.checkout("TMP", ["-b"])
+    sub2_target = AnnexRepo(sub2_pub, create=True)
+    sub2_target.checkout("TMP", ["-b"])
+    sub1 = GitRepo(opj(src_path, 'subm 1'), create=False)
+    sub2 = GitRepo(opj(src_path, '2'), create=False)
+    sub1.add_remote("target", sub1_pub)
+    sub2.add_remote("target", sub2_pub)
+
+    res = publish(dataset=source, to="target", path=['test-annex.dat'], result_xfm='paths')
+    # first it would publish data and then push
+    # TODO order is not fixed (yet)
+    #eq_(res, [opj(source.path, 'test-annex.dat'), source.path])
+    eq_(set(res), set([opj(source.path, 'test-annex.dat'), source.path]))
+    # XXX master was not checked out in dst!
+
+    eq_(list(target.get_branch_commits_(DEFAULT_BRANCH)),
+        list(source.repo.get_branch_commits_(DEFAULT_BRANCH)))
+    assert_git_annex_branch_published(source.repo, target)
+
+    # we need compare target/<default branch>:
+    target.checkout(DEFAULT_BRANCH)
+    ok_(target.file_has_content('test-annex.dat'))
+
+    # make sure that whatever we published is actually consumable
+    dst_clone = install(
+        dst_clone_path, source=dst_path,
+        result_xfm='datasets', return_type='item-or-list')
+    nok_(dst_clone.repo.file_has_content('test-annex.dat'))
+    res = dst_clone.get('test-annex.dat')
+    ok_(dst_clone.repo.file_has_content('test-annex.dat'))
+
+    res = publish(dataset=source, to="target", path=['.'])
+    # there is nothing to publish on 2nd attempt
+    #eq_(res, ([source, 'test-annex.dat'], []))
+    assert_result_count(res, 1, status='notneeded')
+
+    import glob
+    res = publish(dataset=source, to="target", path=glob.glob1(source.path, '*'))
+    # Note: This leads to recursive publishing, since expansion of '*'
+    #       contains the submodules themselves in this setup
+
+    # only the subdatasets, targets are plain git repos, hence
+    # no file content is pushed, all content in super was pushed
+    # before
+    assert_result_count(res, 3)
+    assert_result_count(res, 1, status='ok', path=sub1.path)
+    assert_result_count(res, 1, status='ok', path=sub2.path)
+    assert_result_count(res, 1, status='notneeded', path=source.path)
+
+    # if we publish again -- nothing to be published
+    res = source.publish(to="target")
+    assert_result_count(res, 1, status='notneeded', path=source.path)
+    # if we drop a file and publish again -- dataset should be published
+    # since git-annex branch was updated
+    source.drop('test-annex.dat')
+    res = source.publish(to="target")
+    assert_result_count(res, 1, status='ok', path=source.path)
+    # and empty again if we try again
+    res = source.publish(to="target")
+    assert_result_count(res, 1, status='notneeded', path=source.path)
+
+    # data integrity check looks identical from all perspectives
+    # minus "note" statements from git-annex
+    eq_(filter_fsck_error_msg(source.repo.fsck()),
+        filter_fsck_error_msg(source.repo.fsck(remote='target')))
+    eq_(filter_fsck_error_msg(target.fsck()),
+        filter_fsck_error_msg(source.repo.fsck(remote='target')))
+
+
+@slow  # 10sec on travis
+@skip_if_on_windows  # create_sibling incompatible with win servers
+@skip_ssh
+@with_testrepos('submodule_annex', flavors=['local'])
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile()
+@with_tempfile()
+def test_publish_depends(
+        origin,
+        src_path,
+        target1_path,
+        target2_path,
+        target3_path):
+    # prepare src
+    source = install(src_path, source=origin, recursive=True)
+    source.repo.get('test-annex.dat')
+    # pollute config
+    depvar = 'remote.target2.datalad-publish-depends'
+    source.config.add(depvar, 'stupid', where='local')
+    eq_(source.config.get(depvar, None), 'stupid')
+
+    # two remote sibling on two "different" hosts
+    source.create_sibling(
+        'ssh://datalad-test' + target1_path,
+        annex_wanted='standard',
+        annex_group='backup',
+        name='target1')
+    # fails with unknown remote
+    res = source.create_sibling(
+        'ssh://datalad-test' + target2_path,
+        name='target2',
+        existing='reconfigure',  # because 'target2' is known in polluted cfg
+        publish_depends='bogus',
+        on_failure='ignore')
+    assert_result_count(
+        res, 1,
+        path=source.path,
+        status='error',
+        message=(
+            'unknown sibling(s) specified as publication dependency: %s',
+            set(['bogus'])))
+    # for real
+    source.create_sibling(
+        'ssh://datalad-test' + target2_path,
+        name='target2',
+        existing='reconfigure',  # because 'target2' is known in polluted cfg
+        annex_wanted='standard',
+        annex_group='backup',
+        publish_depends='target1')
+    # wiped out previous dependencies
+    eq_(source.config.get(depvar, None), 'target1')
+    # and one more remote, on the same host but associated with a dependency
+    source.create_sibling(
+        'ssh://datalad-test' + target3_path,
+        name='target3')
+    assert_repo_status(src_path)
+    # introduce change in source
+    create_tree(src_path, {'probe1': 'probe1'})
+    source.save('probe1')
+    assert_repo_status(src_path)
+    # only the source has the probe
+    ok_file_has_content(opj(src_path, 'probe1'), 'probe1')
+    for p in (target1_path, target2_path, target3_path):
+        assert_false(lexists(opj(p, 'probe1')))
+    # publish to a standalone remote
+    source.publish(to='target3')
+    ok_(lexists(opj(target3_path, 'probe1')))
+    # but it has no data copied
+    target3 = Dataset(target3_path)
+    nok_(target3.repo.file_has_content('probe1'))
+
+    # but if we publish specifying its path, it gets copied
+    source.publish('probe1', to='target3')
+    ok_file_has_content(opj(target3_path, 'probe1'), 'probe1')
+
+    # no others are affected in either case
+    for p in (target1_path, target2_path):
+        assert_false(lexists(opj(p, 'probe1')))
+
+    # publish to all remaining, but via a dependency
+    source.publish(to='target2')
+    for p in (target1_path, target2_path, target3_path):
+        ok_file_has_content(opj(p, 'probe1'), 'probe1')
+
+
+@known_failure_windows
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_gh1426(origin_path, target_path):
+    # set up a pair of repos, one the published copy of the other
+    origin = create(origin_path)
+    target = AnnexRepo(target_path, create=True)
+    target.config.set(
+        'receive.denyCurrentBranch', 'updateInstead', where='local')
+    origin.siblings('add', name='target', url=target_path)
+    origin.publish(to='target')
+    assert_repo_status(origin.path)
+    assert_repo_status(target.path)
+    eq_(origin.repo.get_hexsha(), target.get_hexsha())
+
+    # gist of #1426 is that a newly added subdataset does not cause the
+    # superdataset to get published
+    origin.create('sub')
+    assert_repo_status(origin.path)
+    assert_not_equal(origin.repo.get_hexsha(), target.get_hexsha())
+    # now push
+    res = origin.publish(to='target')
+    assert_result_count(res, 1)
+    assert_result_count(res, 1, status='ok', type='dataset', path=origin.path)
+    eq_(origin.repo.get_hexsha(), target.get_hexsha())
+
+
+@skip_if_on_windows  # create_sibling incompatible with win servers
+@skip_ssh
+@with_testrepos('submodule_annex', flavors=['local'])  #TODO: Use all repos after fixing them
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_publish_gh1691(origin, src_path, dst_path):
+
+    # prepare src; no subdatasets installed, but mount points present
+    source = install(src_path, source=origin, recursive=False)
+    ok_(exists(opj(src_path, "subm 1")))
+    assert_false(Dataset(opj(src_path, "subm 1")).is_installed())
+
+    # some content modification of the superdataset
+    create_tree(src_path, {'probe1': 'probe1'})
+    source.save('probe1')
+    assert_repo_status(src_path)
+
+    # create the target(s):
+    source.create_sibling(
+        'ssh://datalad-test:' + dst_path,
+        name='target', recursive=True)
+
+    # publish recursively, which silently ignores non-installed datasets
+    results = source.publish(to='target', recursive=True)
+    assert_result_count(results, 1)
+    assert_result_count(results, 1, status='ok', type='dataset', path=source.path)
+
+    # if however, a non-installed subdataset is requested explicitly, it'll fail
+    results = source.publish(path='subm 1', to='target', on_failure='ignore')
+    assert_result_count(results, 1, status='impossible', type='dataset', action='publish')
+
+
+@skip_if_on_windows  # create_sibling incompatible with win servers
+@skip_ssh
+@with_tree(tree={'1': '123'})
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+def test_publish_target_url(src, desttop, desturl):
+    # https://github.com/datalad/datalad/issues/1762
+    ds = Dataset(src).create(force=True)
+    ds.save('1')
+    ds.create_sibling('ssh://datalad-test:%s/subdir' % desttop,
+                      name='target',
+                      target_url=desturl + 'subdir/.git')
+    results = ds.publish(to='target', transfer_data='all')
+    assert results
+    ok_file_has_content(_path_(desttop, 'subdir/1'), '123')
+
+
+@slow  # 11sec on Yarik's laptop
+@skip_if_on_windows  # create_sibling incompatible with win servers
+@skip_ssh
+@with_tempfile(mkdir=True)
+@with_tempfile()
+@with_tempfile()
+def test_gh1763(src, target1, target2):
+    # this test is very similar to test_publish_depends, but more
+    # comprehensible, and directly tests issue 1763
+    src = Dataset(src).create(force=True)
+    src.create_sibling(
+        'ssh://datalad-test' + target1,
+        name='target1')
+    src.create_sibling(
+        'ssh://datalad-test' + target2,
+        name='target2',
+        publish_depends='target1')
+    # a file to annex
+    create_tree(src.path, {'probe1': 'probe1'})
+    src.save('probe1', to_git=False)
+    # make sure the probe is annexed, not straight in Git
+    assert_in('probe1', src.repo.get_annexed_files(with_content_only=True))
+    # publish to target2, must handle dependency
+    src.publish(to='target2', transfer_data='all')
+    for target in (target1, target2):
+        assert_in(
+            'probe1',
+            Dataset(target).repo.get_annexed_files(with_content_only=True))
+
+
+@with_tempfile()
+@with_tempfile()
+def test_gh1811(srcpath, clonepath):
+    orig = Dataset(srcpath).create()
+    (orig.pathobj / 'some').write_text('some')
+    orig.save()
+    clone = install(source=orig.path, path=clonepath)
+    (clone.pathobj / 'somemore').write_text('somemore')
+    clone.save()
+    clone.repo.call_git(['checkout', 'HEAD~1'])
+    res = clone.publish(to=DEFAULT_REMOTE, on_failure='ignore')
+    assert_result_count(res, 1)
+    assert_result_count(
+        res, 1,
+        path=clone.path, type='dataset', action='publish',
+        status='impossible',
+        message=('Cannot determine remote branch name from %s', 'HEAD'))
+
+
+@with_tempfile(mkdir=True)
+def test_publish_no_fetch_refspec_configured(path):
+
+    path = Path(path)
+    GitWitlessRunner(cwd=str(path)).run(
+        ["git", "init", "--bare", "empty-remote"])
+    ds = Dataset(path / "ds").create()
+    ds.repo.add_remote(DEFAULT_REMOTE, str(ds.pathobj.parent / "empty-remote"))
+    # Mimic a situation that can happen with an LFS remote. See gh-4199.
+    ds.repo.config.unset(f"remote.{DEFAULT_REMOTE}.fetch", where="local")
+    (ds.repo.pathobj / "foo").write_text("a")
+    ds.save()
+    ds.publish(to=DEFAULT_REMOTE)
+
+
+@known_failure_windows
+@slow  # 14sec on Yarik's laptop
+@skip_ssh
+@with_tempfile(mkdir=True)
+def test_publish_fetch_do_not_recurse_submodules(path):
+    # This sets up a situation where git (2.26.2 at the time of writing) will
+    # fail trying to fetch a non-existent 'origin' remote if
+    # --no-recurse-submodules is not set during the fetch.
+    path = Path(path)
+    ds_a = Dataset(path / "a").create()
+    ds_a.create("sub")
+    ds_a.save(recursive=True)
+    # TODO: This can be switched to a local path on master, dropping the
+    # skip_ssh().
+    ds_a.create_sibling("ssh://datalad-test:{}/b".format(path), name="b",
+                        recursive=True)
+    publish(dataset=ds_a, to="b")
+
+    ds_b = Dataset(path / "b")
+    ds_b.repo.checkout("other", options=["-b"])
+    (ds_b.pathobj / "sub" / "foo").write_text("foo")
+    ds_b.save(recursive=True)
+
+    (ds_a.pathobj / "bar").write_text("bar")
+    ds_a.save()
+    assert_status("ok", publish(dataset=ds_a, to="b"))

--- a/datalad_deprecated/tests/test_publish.py
+++ b/datalad_deprecated/tests/test_publish.py
@@ -15,12 +15,16 @@ from os.path import (
     join as opj,
     lexists,
 )
-from ..dataset import Dataset
+from datalad.distribution.dataset import Dataset
 from datalad.api import (
     create,
     install,
-    publish,
 )
+from datalad_deprecated.publish import Publish
+# emulate API provided function interface to make sure
+# we are testing the implementation in deprecated and
+# not a potentially existing one in a -core installation
+publish = Publish()
 from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ High-level API commands
    :toctree: generated
 
    ls
+   publish
 
 
 Command line reference
@@ -21,6 +22,7 @@ Command line reference
    :maxdepth: 1
 
    generated/man/datalad-ls
+   generated/man/datalad-publish
 
 
 Miscellaneous functionality


### PR DESCRIPTION
Acting on the deprecation in 0.13: https://github.com/datalad/datalad/issues/4494

A companion PR in -core will be posted shortly.

Once merged, the issues listed in https://github.com/datalad/datalad/issues/4494 can be moved to this project.

Companion PR in -core is https://github.com/datalad/datalad/pull/5837