### PR TITLE
Import deprecated GitRepo.*_submodule() methods

### DIFF
--- a/datalad_deprecated/gitrepo.py
+++ b/datalad_deprecated/gitrepo.py
@@ -1,0 +1,247 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Internal low-level interface to Git repositories
+
+"""
+
+import os.path as op
+
+import logging
+from os.path import (
+    join as opj,
+    exists,
+    isabs,
+    curdir,
+)
+
+import posixpath
+import warnings
+
+from datalad.utils import (
+    Path,
+    posix_relpath,
+)
+
+from datalad.support.gitrepo import (
+    GitRepo,
+)
+from datalad.support.exceptions import (
+    InvalidGitRepositoryError,
+)
+from datalad.core.local.repo import repo_from_path
+
+lgr = logging.getLogger('datalad.gitrepo')
+
+
+class DeprecatedGitRepoMethods(object):
+    """This class is just a container for GitRepo methods that have been deprecated
+    in -core. The can be moved here to rot in peace.
+    """
+
+    def add_submodule(self, path, name=None, url=None, branch=None):
+        """Add a new submodule to the repository.
+
+        This will alter the index as well as the .gitmodules file, but will not
+        create a new commit.  If the submodule already exists, no matter if the
+        configuration differs from the one provided, the existing submodule
+        is considered as already added and no further action is performed.
+
+        NOTE: This method does not work with submodules that use git-annex adjusted
+              branches. Use Repo.save() instead.
+
+        Parameters
+        ----------
+        path : str
+          repository-relative path at which the submodule should be located, and
+          which will be created as required during the repository initialization.
+        name : str or None
+          name/identifier for the submodule. If `None`, the `path` will be used
+          as name.
+        url : str or None
+          git-clone compatible URL. If `None`, the repository is assumed to
+          exist, and the url of the first remote is taken instead. This is
+          useful if you want to make an existing repository a submodule of
+          another one.
+        branch : str or None
+          name of branch to be checked out in the submodule. The given branch
+          must exist in the remote repository, and will be checked out locally
+          as a tracking branch. If `None`, remote HEAD will be checked out.
+        """
+        warnings.warn(
+            'GitRepo.add_submodule() is deprecated and will be removed in '
+            'a future release. Use the Dataset method save() instead.',
+            DeprecationWarning
+        )
+
+        if name is None:
+            name = Path(path).as_posix()
+        cmd = ['submodule', 'add', '--name', name]
+        if branch is not None:
+            cmd += ['-b', branch]
+        if url is None:
+            # repo must already exist locally
+            subm = repo_from_path(op.join(self.path, path))
+            # check that it has a commit, and refuse
+            # to operate on it otherwise, or we would get a bastard
+            # submodule that cripples git operations
+            if not subm.get_hexsha():
+                raise InvalidGitRepositoryError(
+                    'cannot add subdataset {} with no commits'.format(subm))
+            # make an attempt to configure a submodule source URL based on the
+            # discovered remote configuration
+            remote, branch = subm.get_tracking_branch()
+            url = subm.get_remote_url(remote) if remote else None
+
+        if url is None:
+            # had no luck with a remote URL
+            if not isabs(path):
+                # need to recode into a relative path "URL" in POSIX
+                # style, even on windows
+                url = posixpath.join(curdir, posix_relpath(path))
+            else:
+                url = path
+        cmd += [url, Path(path).as_posix()]
+        self.call_git(cmd)
+        # record dataset ID if possible for comprehesive metadata on
+        # dataset components within the dataset itself
+        subm_id = GitRepo(op.join(self.path, path)).config.get(
+            'datalad.dataset.id', None)
+        if subm_id:
+            self.call_git(
+                ['config', '--file', '.gitmodules', '--replace-all',
+                 'submodule.{}.datalad-id'.format(name), subm_id])
+        # ensure supported setup
+        from datalad.support.gitrepo import _fixup_submodule_dotgit_setup
+        _fixup_submodule_dotgit_setup(self, path)
+        # TODO: return value
+
+    def deinit_submodule(self, path, **kwargs):
+        """Deinit a submodule
+
+        Parameters
+        ----------
+        path: str
+            path to the submodule; relative to `self.path`
+        kwargs:
+            see `__init__`
+        """
+        warnings.warn(
+            'GitRepo.deinit_submodule() is deprecated and will be removed in '
+            'a future release. Use call_git() instead.',
+            DeprecationWarning
+        )
+        from datalad.support.gitrepo import to_options
+        self.call_git(['submodule', 'deinit'] + to_options(**kwargs),
+                      files=[path])
+        # TODO: return value
+
+    def update_submodule(self, path, mode='checkout', init=False):
+        """Update a registered submodule.
+
+        This will make the submodule match what the superproject expects by
+        cloning missing submodules and updating the working tree of the
+        submodules. The "updating" can be done in several ways depending
+        on the value of submodule.<name>.update configuration variable, or
+        the `mode` argument.
+
+        Parameters
+        ----------
+        path : str
+          Identifies which submodule to operate on by it's repository-relative
+          path.
+        mode : {checkout, rebase, merge}
+          Update procedure to perform. 'checkout': the commit recorded in the
+          superproject will be checked out in the submodule on a detached HEAD;
+          'rebase': the current branch of the submodule will be rebased onto
+          the commit recorded in the superproject; 'merge': the commit recorded
+          in the superproject will be merged into the current branch in the
+          submodule.
+        init : bool
+          If True, initialize all submodules for which "git submodule init" has
+          not been called so far before updating.
+          Primarily provided for internal purposes and should not be used directly
+          since would result in not so annex-friendly .git symlinks/references
+          instead of full featured .git/ directories in the submodules
+        """
+        warnings.warn(
+            'GitRepo.update_submodule() is deprecated and will be removed in '
+            'a future release. Use the dataset method update() instead.',
+            DeprecationWarning
+        )
+        if GitRepo.is_valid_repo(self.pathobj / path):
+            subrepo = GitRepo(self.pathobj / path, create=False)
+            subbranch = subrepo.get_active_branch() if subrepo else None
+            try:
+                subbranch_hexsha = subrepo.get_hexsha(subbranch) if subrepo else None
+            except ValueError:
+                if subrepo.commit_exists("HEAD"):
+                    # Not what we thought it was. Reraise.
+                    raise
+                else:
+                    raise ValueError(
+                        "Cannot add submodule that has an unborn branch "
+                        "checked out: {}"
+                        .format(subrepo.path))
+
+        else:
+            subrepo = None
+            subbranch = None
+            subbranch_hexsha = None
+
+        cmd = ['submodule', 'update', '--%s' % mode]
+        if init:
+            cmd.append('--init')
+            subgitpath = opj(self.path, path, '.git')
+            if not exists(subgitpath):
+                # TODO:  wouldn't with --init we get all those symlink'ed .git/?
+                # At least let's warn
+                lgr.warning(
+                    "Do not use update_submodule with init=True to avoid git creating "
+                    "symlinked .git/ directories in submodules"
+                )
+            #  yoh: I thought I saw one recently but thought it was some kind of
+            #  an artifact from running submodule update --init manually at
+            #  some point, but looking at this code now I worry that it was not
+        self.call_git(cmd, files=[path])
+
+        if not init:
+            return
+
+        # track branch originally cloned, only if we had a valid repo at the start
+        updated_subbranch = subrepo.get_active_branch() if subrepo else None
+        if subbranch and not updated_subbranch:
+            # got into 'detached' mode
+            # trace if current state is a predecessor of the branch_hexsha
+            lgr.debug(
+                "Detected detached HEAD after updating submodule %s which was "
+                "in %s branch before", self.path, subbranch)
+            detached_hexsha = subrepo.get_hexsha()
+            if subrepo.get_merge_base(
+                    [subbranch_hexsha, detached_hexsha]) == detached_hexsha:
+                # TODO: config option?
+                # in all likely event it is of the same branch since
+                # it is an ancestor -- so we could update that original branch
+                # to point to the state desired by the submodule, and update
+                # HEAD to point to that location
+                lgr.info(
+                    "Submodule HEAD got detached. Resetting branch %s to point "
+                    "to %s. Original location was %s",
+                    subbranch, detached_hexsha[:8], subbranch_hexsha[:8]
+                )
+                branch_ref = 'refs/heads/%s' % subbranch
+                subrepo.update_ref(branch_ref, detached_hexsha)
+                assert(subrepo.get_hexsha(subbranch) == detached_hexsha)
+                subrepo.update_ref('HEAD', branch_ref, symbolic=True)
+                assert(subrepo.get_active_branch() == subbranch)
+            else:
+                lgr.warning(
+                    "%s has a detached HEAD since cloned branch %s has another common ancestor with %s",
+                    subrepo.path, subbranch, detached_hexsha[:8]
+                )
+        # TODO: return value

--- a/datalad_deprecated/tests/test_annexrepo.py
+++ b/datalad_deprecated/tests/test_annexrepo.py
@@ -1,0 +1,41 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test implementation of class GitRepo
+
+"""
+
+from os.path import join as opj
+
+from datalad.support.annexrepo import AnnexRepo
+
+from datalad.tests.utils import (
+    assert_repo_status,
+    eq_,
+    skip_if_adjusted_branch,
+    with_tempfile,
+)
+
+
+@skip_if_adjusted_branch
+@with_tempfile
+@with_tempfile
+def test_AnnexRepo_add_submodule(source_path, path):
+    source = AnnexRepo(source_path, create=True)
+    (source.pathobj / 'test-annex.dat').write_text("content")
+    source.save('some')
+
+    top_repo = AnnexRepo(path, create=True)
+
+    top_repo.add_submodule('sub', name='sub', url=source_path)
+    top_repo.commit('submodule added')
+    eq_([s["gitmodule_name"] for s in top_repo.get_submodules_()],
+        ['sub'])
+
+    assert_repo_status(top_repo, annex=True)
+    assert_repo_status(opj(path, 'sub'), annex=False)

--- a/datalad_deprecated/tests/test_gitrepo.py
+++ b/datalad_deprecated/tests/test_gitrepo.py
@@ -1,0 +1,187 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test implementation of class GitRepo
+
+"""
+
+import logging
+
+import os.path as op
+
+from datalad.tests.utils import (
+    assert_false,
+    assert_in,
+    assert_raises,
+    assert_repo_status,
+    DEFAULT_BRANCH,
+    eq_,
+    ok_,
+    SkipTest,
+    swallow_logs,
+    with_tempfile,
+)
+
+# we nevertheless import from -core
+# which must provide all deprecated methods whenever
+# this package is installed too
+from datalad.support.gitrepo import GitRepo
+from datalad.support.exceptions import (
+    CommandError,
+)
+
+
+@with_tempfile
+@with_tempfile
+@with_tempfile
+def test_submodule_deinit(src, subsrc, path):
+    src = GitRepo(src)
+    subsrc = GitRepo(subsrc)
+    for repo in (src, subsrc):
+        for filename in ('some1.txt', 'some2.dat'):
+            with open(op.join(repo.path, filename), 'w') as f:
+                f.write(filename)
+            repo.add(filename)
+        repo.commit('Some files')
+    src.add_submodule('subm 1', name='subm 1', url=subsrc.path)
+    src.add_submodule('2', name='2', url=subsrc.path)
+    src.commit('submodule added')
+
+    top_repo = GitRepo.clone(src.path, path)
+    eq_({'subm 1', '2'},
+        {s["gitmodule_name"] for s in top_repo.get_submodules_()})
+    # note: here init=True is ok, since we are using it just for testing
+    with swallow_logs(new_level=logging.WARN) as cml:
+        top_repo.update_submodule('subm 1', init=True)
+        assert_in('Do not use update_submodule with init=True', cml.out)
+    top_repo.update_submodule('2', init=True)
+
+    # ok_(all([s.module_exists() for s in top_repo.get_submodules()]))
+    # TODO: old assertion above if non-bare? (can't use "direct mode" in test_gitrepo)
+    # Alternatively: New testrepo (plain git submodules) and have a dedicated
+    # test for annexes in addition
+    ok_(all(GitRepo.is_valid_repo(s["path"])
+            for s in top_repo.get_submodules_()))
+
+    # modify submodule:
+    with open(op.join(top_repo.path, 'subm 1', 'file_ut.dat'), "w") as f:
+        f.write("some content")
+
+    assert_raises(CommandError, top_repo.deinit_submodule, 'sub1')
+
+    # using force should work:
+    top_repo.deinit_submodule('subm 1', force=True)
+
+    ok_(not GitRepo.is_valid_repo(str(top_repo.pathobj / 'subm 1')))
+
+
+@with_tempfile(mkdir=True)
+@with_tempfile(mkdir=True)
+def test_GitRepo_add_submodule(source_path, path):
+    source = GitRepo(source_path, create=True)
+    with open(op.join(source_path, 'some.txt'), 'w') as f:
+        f.write("New text file.")
+    source.add('some.txt')
+    source.commit('somefile')
+
+    top_repo = GitRepo(path, create=True)
+
+    top_repo.add_submodule('sub', name='sub', url=source_path)
+    top_repo.commit('submodule added')
+    eq_([s["gitmodule_name"] for s in top_repo.get_submodules_()],
+        ['sub'])
+    assert_repo_status(path)
+    assert_repo_status(op.join(path, 'sub'))
+
+
+def test_GitRepo_update_submodule():
+    raise SkipTest("TODO")
+
+
+@with_tempfile(mkdir=True)
+def check_update_submodule_init_adjust_branch(is_ancestor, path):
+    src = GitRepo(op.join(path, "src"), create=True)
+    src_sub = GitRepo(op.join(src.path, "sub"), create=True)
+    src_sub.commit(msg="c0", options=["--allow-empty"])
+    src_sub.commit(msg="c1", options=["--allow-empty"])
+    src.add_submodule('sub', name='sub')
+    src.commit(msg="Add submodule")
+
+    # Move subdataset past the registered commit...
+    hexsha_registered = src_sub.get_hexsha()
+    if is_ancestor:
+        # ... where the registered commit is an ancestor of the new one.
+        src_sub.commit(msg="c2", options=["--allow-empty"])
+    else:
+        # ... where the registered commit is NOT an ancestor of the new one.
+        src_sub.call_git(["reset", "--hard", DEFAULT_BRANCH + "~1"])  # c0
+    hexsha_sub = src_sub.get_hexsha()
+
+    clone = GitRepo.clone(url=src.path,
+                          path=op.join(path, "clone"),
+                          create=True)
+    clone_sub = GitRepo.clone(url=src_sub.path,
+                              path=op.join(clone.path, "sub"),
+                              create=True)
+    ok_(clone.dirty)
+    eq_(clone_sub.get_active_branch(), DEFAULT_BRANCH)
+    eq_(hexsha_sub, clone_sub.get_hexsha())
+
+    clone.update_submodule("sub", init=True)
+
+    assert_false(clone.dirty)
+    eq_(hexsha_registered, clone_sub.get_hexsha())
+    if is_ancestor:
+        eq_(clone_sub.get_active_branch(), DEFAULT_BRANCH)
+    else:
+        assert_false(clone_sub.get_active_branch())
+
+
+def test_GitRepo_update_submodule_init_adjust_branch():
+    yield check_update_submodule_init_adjust_branch, True
+    yield check_update_submodule_init_adjust_branch, False
+
+
+@with_tempfile
+def test_update_submodules_sub_on_unborn_branch(path):
+    repo = GitRepo(path, create=True)
+    repo.commit(msg="c0", options=["--allow-empty"])
+    subrepo = GitRepo(op.join(path, "sub"), create=True)
+    subrepo.commit(msg="s c0", options=["--allow-empty"])
+    repo.add_submodule(path="sub")
+    subrepo.checkout("other", options=["--orphan"])
+    with assert_raises(ValueError) as cme:
+        repo.update_submodule(path="sub")
+    assert_in("unborn branch", str(cme.exception))
+
+
+@with_tempfile
+def test_GitRepo_get_submodules(path):
+    repo = GitRepo(path, create=True)
+
+    s_abc = GitRepo(op.join(path, "s_abc"), create=True)
+    s_abc.commit(msg="c s_abc", options=["--allow-empty"])
+    repo.add_submodule(path="s_abc")
+
+    s_xyz = GitRepo(op.join(path, "s_xyz"), create=True)
+    s_xyz.commit(msg="c s_xyz", options=["--allow-empty"])
+    repo.add_submodule(path="s_xyz")
+
+    eq_([s["gitmodule_name"]
+         for s in repo.get_submodules(sorted_=True)],
+        ["s_abc", "s_xyz"])
+
+
+@with_tempfile
+def test_get_submodules_parent_on_unborn_branch(path):
+    repo = GitRepo(path, create=True)
+    subrepo = GitRepo(op.join(path, "sub"), create=True)
+    subrepo.commit(msg="s", options=["--allow-empty"])
+    repo.add_submodule(path="sub")
+    eq_([s["gitmodule_name"] for s in repo.get_submodules_()],
+        ["sub"])


### PR DESCRIPTION
This methods are not used in -core for a long time.

The import includes their tests, as far as they existed.

https://github.com/datalad/datalad/pull/6010 is the -core companion PR that enables the usual type of automatic retro-fitting, whenever the -deprecated package is installed.