### PR TITLE
Properly include "data packages" in project

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,13 +19,11 @@ install_requires =
 test_requires =
     nose
     coverage
-packages = find:
+packages = find_namespace:
 include_package_data = True
 
 [options.packages.find]
-# do not ship the build helpers
-exclude=
-    _datalad_buildsupport
+include = datalad_deprecated*
 
 [versioneer]
 # See the docstring in versioneer.py for instructions. Note that you must


### PR DESCRIPTION
There are several folders in `datalad_deprecated/` that contain data files but no Python source code, and we want these to be included when datalad-deprecated is installed.  Currently, these folders are automatically included by the combination of `graft datalad_deprecated/resources` in `MANIFEST.in` and `include_package_data = True` in `setup.cfg`, but because we set `packages` in `setup.cfg` to `find:` instead of `find_namespace:`, the folders themselves are not recognized by setuptools as packages.  [This combination of settings is deprecated](https://github.com/pypa/setuptools/issues/3340), and the setuptools developers recommend using `find_namespace:` instead of `find:` for such situations.