### PR TITLE
BF: do not install devel datalad (pytest-ed now) for devel -- released is ok now

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -7,6 +7,3 @@ sphinx_rtd_theme
 # for automagicio tests
 nibabel
 h5py
-
-# for web UI transition
-git+https://github.com/datalad/datalad#egg=datalad


### PR DESCRIPTION
Otherwise we start requiring pytest but that to be done properly
in https://github.com/datalad/datalad-deprecated/pull/51
after datalad releases 0.17.0