### PR TITLE
Remove last traces of `datalad.metadata`

### DIFF
--- a/datalad_deprecated/metadata/extractors/annex.py
+++ b/datalad_deprecated/metadata/extractors/annex.py
@@ -8,16 +8,16 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Metadata extractor for Git-annex metadata"""
 
-from datalad.metadata.extractors.base import BaseMetadataExtractor
 
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.annexmeta')
 from datalad.log import log_progress
 
 from datalad.support.annexrepo import AnnexRepo
-# use main version as core version
+
 # this must stay, despite being a seemingly unused import, each extractor defines a version
-from datalad.metadata.definitions import version as vocabulary_version
+from ..definitions import version as vocabulary_version
+from .base import BaseMetadataExtractor
 
 
 class MetadataExtractor(BaseMetadataExtractor):

--- a/datalad_deprecated/metadata/extractors/audio.py
+++ b/datalad_deprecated/metadata/extractors/audio.py
@@ -15,8 +15,9 @@ lgr = logging.getLogger('datalad.metadata.extractors.audio')
 from datalad.log import log_progress
 
 from mutagen import File as audiofile
-from datalad.metadata.definitions import vocabulary_id
-from datalad.metadata.extractors.base import BaseMetadataExtractor
+
+from ..definitions import vocabulary_id
+from .base import BaseMetadataExtractor
 
 
 # how properties reported by mutagen map onto our vocabulary

--- a/datalad_deprecated/metadata/extractors/datacite.py
+++ b/datalad_deprecated/metadata/extractors/datacite.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     import xml.etree.ElementTree as ET
 
-from datalad.metadata.extractors.base import BaseMetadataExtractor
+from .base import BaseMetadataExtractor
 
 
 def _merge(iterable):

--- a/datalad_deprecated/metadata/extractors/datalad_core.py
+++ b/datalad_deprecated/metadata/extractors/datalad_core.py
@@ -8,8 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Metadata extractor for DataLad's own core storage"""
 
-from datalad.metadata.extractors.base import BaseMetadataExtractor
-
 import logging
 lgr = logging.getLogger('datalad.metadata.extractors.datalad_core')
 from datalad.log import log_progress
@@ -22,6 +20,7 @@ from datalad.support.json_py import load as jsonload
 from datalad.support.annexrepo import AnnexRepo
 from datalad.coreapi import subdatasets
 
+from .base import BaseMetadataExtractor
 from ..consts import (
     DATASET_METADATA_FILE,
     DATALAD_DOTDIR,

--- a/datalad_deprecated/metadata/extractors/datalad_rfc822.py
+++ b/datalad_deprecated/metadata/extractors/datalad_rfc822.py
@@ -23,8 +23,9 @@ from os.path import exists
 import email
 import email.parser  # necessary on Python 2.7.6 (trusty)
 from os.path import join as opj
-from datalad.metadata.extractors.base import BaseMetadataExtractor
 from datalad.interface.base import dedent_docstring
+
+from .base import BaseMetadataExtractor
 
 
 def _split_list_field(content):

--- a/datalad_deprecated/metadata/extractors/exif.py
+++ b/datalad_deprecated/metadata/extractors/exif.py
@@ -14,8 +14,9 @@ lgr = logging.getLogger('datalad.metadata.extractors.exif')
 from datalad.log import log_progress
 
 from exifread import process_file
-from datalad.metadata.definitions import vocabulary_id
-from datalad.metadata.extractors.base import BaseMetadataExtractor
+
+from ..definitions import vocabulary_id
+from .base import BaseMetadataExtractor
 
 
 def _return_as_appropriate_dtype(val):

--- a/datalad_deprecated/metadata/extractors/frictionless_datapackage.py
+++ b/datalad_deprecated/metadata/extractors/frictionless_datapackage.py
@@ -14,7 +14,8 @@ import logging
 lgr = logging.getLogger('datalad.metadata.extractors.frictionless_datapackage')
 from os.path import join as opj, exists
 from datalad.support.json_py import load as jsonload
-from datalad.metadata.extractors.base import BaseMetadataExtractor
+
+from .base import BaseMetadataExtractor
 
 
 def _compact_author(obj):

--- a/datalad_deprecated/metadata/extractors/image.py
+++ b/datalad_deprecated/metadata/extractors/image.py
@@ -14,8 +14,10 @@ lgr = logging.getLogger('datalad.metadata.extractors.image')
 from datalad.log import log_progress
 
 from PIL import Image
-from datalad.metadata.extractors.base import BaseMetadataExtractor
 from datalad.support.exceptions import CapturedException
+
+from .base import BaseMetadataExtractor
+
 
 vocabulary = {
     "spatial_resolution(dpi)": {

--- a/datalad_deprecated/metadata/extractors/tests/test_frictionless_datapackage.py
+++ b/datalad_deprecated/metadata/extractors/tests/test_frictionless_datapackage.py
@@ -11,15 +11,13 @@
 import json
 
 from datalad.api import Dataset
-from datalad.metadata.extractors.frictionless_datapackage import (
-    MetadataExtractor,
-)
 from datalad.tests.utils_pytest import (
     assert_equal,
     with_tree,
 )
 
 from ... import skip_if_on_windows
+from ..frictionless_datapackage import MetadataExtractor
 
 
 # bits from examples and the specs

--- a/datalad_deprecated/metadata/extractors/tests/test_rfc822.py
+++ b/datalad_deprecated/metadata/extractors/tests/test_rfc822.py
@@ -11,13 +11,13 @@
 import json
 
 from datalad.distribution.dataset import Dataset
-from datalad.metadata.extractors.datalad_rfc822 import MetadataExtractor
 from datalad.tests.utils_pytest import (
     assert_equal,
     with_tree,
 )
 
 from ... import skip_if_on_windows
+from ..datalad_rfc822 import MetadataExtractor
 
 
 @with_tree(tree={'.datalad': {'meta.rfc822': """\

--- a/datalad_deprecated/metadata/extractors/xmp.py
+++ b/datalad_deprecated/metadata/extractors/xmp.py
@@ -18,9 +18,10 @@ lgr = logging.getLogger('datalad.metadata.extractors.xmp')
 from datalad.log import log_progress
 
 from libxmp.utils import file_to_dict
-from datalad.metadata.definitions import vocabulary_id
-from datalad.metadata.extractors.base import BaseMetadataExtractor
 from datalad.utils import ensure_unicode
+
+from ..definitions import vocabulary_id
+from .base import BaseMetadataExtractor
 
 
 xmp_field_re = re.compile(r'^([^\[\]]+)(\[\d+\]|)(/?.*|)')


### PR DESCRIPTION
This PR removes the remaining references to `datalad.metadata`, that were left in the test code by mistake.