### PR TITLE
Crossport core-located metadata bug-fixes

### DIFF
--- a/datalad_deprecated/metadata/aggregate.py
+++ b/datalad_deprecated/metadata/aggregate.py
@@ -23,7 +23,7 @@ import shutil
 
 import datalad
 from datalad.consts import DATASET_CONFIG_FILE
-
+from datalad.interface.annotate_paths import _minimal_annotate_paths
 from datalad.interface.base import Interface
 from datalad.interface.utils import (
     eval_results,
@@ -61,18 +61,18 @@ from datalad.utils import (
 )
 from datalad.core.local.status import get_paths_by_ds
 
-from .annotate_paths import _minimal_annotate_paths
-from .consts import DATASET_METADATA_FILE
 from .metadata import (
-    exclude_from_metadata,
     get_ds_aggregate_db_locations,
-    get_metadata_type,
     load_ds_aggregate_db,
-    location_keys,
+    exclude_from_metadata,
+    get_metadata_type,
     _get_metadata,
     _get_metadatarelevant_paths,
     _get_containingds_from_agginfo,
+    location_keys,
 )
+
+from .consts import DATASET_METADATA_FILE
 from .utils import all_same
 
 

--- a/datalad_deprecated/metadata/metadata.py
+++ b/datalad_deprecated/metadata/metadata.py
@@ -351,9 +351,9 @@ def _query_aggregated_metadata_singlepath(
     rpath = qap['rpath']
     containing_ds = qap['metaprovider']
     qtype = qap.get('type', None)
-    if (rpath == op.curdir or rpath == containing_ds) and \
-            ((reporton is None and qtype == 'dataset') or \
-             reporton in ('datasets', 'all')):
+    if (rpath == op.curdir or rpath == containing_ds) \
+        and ((reporton is None and qtype == 'dataset')
+             or reporton in ('datasets', 'all')):
         # this is a direct match for a dataset (we only have agginfos for
         # datasets) -> prep result
         res = get_status_dict(

--- a/datalad_deprecated/metadata/search.py
+++ b/datalad_deprecated/metadata/search.py
@@ -54,9 +54,9 @@ from datalad.utils import (
     get_suggestions_msg,
     shortened_repr,
 )
-
 from datalad_deprecated.metadata.metadata import query_aggregated_metadata
-from datalad_deprecated.metadata.utils import (
+
+from .utils import (
     as_unicode,
     unicode_srctypes,
 )
@@ -777,7 +777,7 @@ class _EGrepCSSearch(_Search):
     _mode_label = 'egrepcs'
     _default_documenttype = 'datasets'
 
-    def __init__(self, ds, metadata_source=None, **kwargs):
+    def __init__(self, ds, metadata_source='all', **kwargs):
         super(_EGrepCSSearch, self).__init__(ds, metadata_source, **kwargs)
         self._queried_keys = None  # to be memoized by get_query
 
@@ -1320,14 +1320,14 @@ class Search(Interface):
             for debugging purposes."""),
         metadata_source=Parameter(
             args=('--metadata-source',),
-            choices=('legacy', 'gen4'),
-            default=None,
+            choices=('legacy', 'gen4', 'all'),
             doc="""if given, defines which metadata source will be used to
             search. 'legacy' will limit search to metadata in the old format,
             i.e. stored in '$DATASET/.datalad/metadata'. 'gen4' will limit
             search to metadata stored by the git-backend of 
-            'datalad-metadata-model'. If not given, metadata from all supported
-            sources will be included in search.""")
+            'datalad-metadata-model'. If 'all' is given, metadata from all
+            supported sources will be included in the search. The default is
+            'legacy'.""")
     )
 
     @staticmethod
@@ -1342,7 +1342,7 @@ class Search(Interface):
                  full_record=False,
                  show_keys=None,
                  show_query=False,
-                 metadata_source=None):
+                 metadata_source='legacy'):
         try:
             ds = require_dataset(dataset, check_installed=True, purpose='dataset search')
             if ds.id is None:
@@ -1357,7 +1357,7 @@ class Search(Interface):
 
         if mode is None:
             # let's get inspired by what the dataset/user think is
-            # default.
+            # default
             mode = ds.config.obtain('datalad.search.default-mode')
 
         if mode == 'egrep':
@@ -1373,7 +1373,10 @@ class Search(Interface):
                 'unknown search mode "{}"'.format(mode))
 
         searcher = searcher(
-            ds, metadata_source=metadata_source, force_reindex=force_reindex)
+            ds,
+            metadata_source=metadata_source,
+            force_reindex=force_reindex
+        )
 
         if show_keys:
             searcher.show_keys(show_keys, regexes=query)

--- a/datalad_deprecated/metadata/tests/test_search.py
+++ b/datalad_deprecated/metadata/tests/test_search.py
@@ -247,7 +247,7 @@ type
     # test default behavior while limiting set of keys reported
     with swallow_outputs() as cmo:
         ds.search([r'\.id', 'artist$'], show_keys='short')
-        out_lines = [l for l in cmo.out.split(os.linesep) if l]
+        out_lines = [l for l in cmo.out.splitlines() if l]
         # test that only the ones matching were returned
         assert_equal(
             [l for l in out_lines if not l.startswith(' ')],

--- a/datalad_deprecated/metadata/tests/test_search.py
+++ b/datalad_deprecated/metadata/tests/test_search.py
@@ -19,7 +19,6 @@ from shutil import copy
 from uuid import UUID
 from pkg_resources import EntryPoint
 
-from unittest import SkipTest
 from unittest.mock import (
     MagicMock,
     patch,
@@ -31,7 +30,7 @@ from datalad.api import (
 )
 from datalad.support.exceptions import NoDatasetFound
 from datalad.tests.utils_pytest import (
-    #SkipTest,
+    SkipTest,
     assert_equal,
     assert_in,
     assert_is_generator,
@@ -40,7 +39,7 @@ from datalad.tests.utils_pytest import (
     assert_repo_status,
     assert_result_count,
     eq_,
-    skip_if_adjusted_branch,
+    known_failure_githubci_win,
     ok_file_under_git,
     patch_config,
     with_tempfile,
@@ -62,7 +61,6 @@ from ..search import (
     _listdict2dictlist,
     _meta2autofield_dict,
 )
-
 
 
 @with_testsui(interactive=False)
@@ -175,7 +173,7 @@ def test_search_non_dataset(tdir=None):
     assert_in("datalad create --force", str(cme.value))
 
 
-@skip_if_adjusted_branch
+@known_failure_githubci_win
 @with_tempfile(mkdir=True)
 def test_within_ds_file_search(path=None):
     try:
@@ -581,14 +579,12 @@ def test_gen4_query_aggregated_metadata():
                 reporton='all',
                 ds=DatasetMock('ds'),
                 aps=mocked_annotated_paths,
+                metadata_source='gen4'
             )
             if metadata_result['status'] == 'ok'
         ]
-        assert_equal(len(result), 1)
-        assert_equal(
-            result[0]['metadata'],
-            {extractor_name: extracted_metadata}
-        )
+        assert len(result) == 1
+        assert result[0]['metadata'] == {extractor_name: extracted_metadata}
 
         # check no metadata found-handling
         dump_mock.reset_mock()
@@ -600,6 +596,7 @@ def test_gen4_query_aggregated_metadata():
                 reporton='all',
                 ds=DatasetMock('ds'),
                 aps=mocked_annotated_paths,
+                metadata_source='all',
             )
             if metadata_result['status'] == 'impossible'
         ]
@@ -636,7 +633,7 @@ def test_metadata_source_handling(temp_dir=None):
         reset_mock(legacy_mock, legacy_result)
         r = tuple(
             result["metadata_source"]
-            for result in search(dataset=temp_ds, query="v1")
+            for result in search(dataset=temp_ds, query="v1", metadata_source='all')
         )
         assert_equal(r, ("legacy", "gen4"))
 

--- a/datalad_deprecated/metadata/utils.py
+++ b/datalad_deprecated/metadata/utils.py
@@ -1,3 +1,4 @@
+from datalad.support.json_py import load_stream
 from datalad.utils import ensure_unicode
 
 
@@ -51,3 +52,7 @@ def as_unicode(val, cast_types=object):
         raise TypeError(
             "Value %r is not of any of known or provided %s types"
             % (val, cast_types))
+
+
+def load_xzstream(fname):
+    yield from load_stream(fname, compressed=True)


### PR DESCRIPTION
This PR adds bug-fixes that have been applied to the metadata core since the metadata code was added to `datalad-deprecated`