### PR TITLE
BF: Adjust imports for metadata move

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Command(s) provided by this extension
 - `ls` -- list summary information about URLs and datasets
    of a dataset (hierarchy)
 - `publish` -- original implementation, replaced by `push` in core
+- metadata commands `search`, `metadata`, `extract-metadata` and
+  `aggregate-metadata`; moved out of core in favor of the `datalad-metalad`
+  extension
 
 
 In addition, this extension provides the `AutomagicIO` feature that patches Python's

--- a/datalad_deprecated/metadata/extractors/tests/test_datacite_xml.py
+++ b/datalad_deprecated/metadata/extractors/tests/test_datacite_xml.py
@@ -17,7 +17,7 @@ from datalad.tests.utils_pytest import (
 )
 
 from ..datacite import MetadataExtractor
-from ...metadata import _get_metadatarelevant_paths
+from datalad_deprecated.metadata.metadata import _get_metadatarelevant_paths
 
 
 xml_content = """\

--- a/datalad_deprecated/metadata/metadata.py
+++ b/datalad_deprecated/metadata/metadata.py
@@ -34,7 +34,6 @@ from datalad.interface.utils import (
     generic_result_renderer,
 )
 from datalad.interface.base import build_doc
-from datalad.metadata.definitions import version as vocabulary_version
 from datalad.support.collections import ReadOnlyDict, _val2hashable
 from datalad.support.constraints import (
     EnsureNone,
@@ -63,7 +62,8 @@ from datalad.ui import ui
 from datalad.dochelpers import single_or_plural
 from datalad.log import log_progress
 from datalad.core.local.status import get_paths_by_ds
-
+from .definitions import version as vocabulary_version
+from .annotate_paths import _minimal_annotate_paths
 from .common_opts import reporton_opt
 from .consts import (
     OLDMETADATA_DIR,

--- a/datalad_deprecated/metadata/tests/test_aggregation.py
+++ b/datalad_deprecated/metadata/tests/test_aggregation.py
@@ -13,7 +13,6 @@
 import os.path as op
 from os.path import join as opj
 
-from datalad.api import metadata
 from datalad.distribution.dataset import Dataset
 from datalad.tests.utils_pytest import (
     assert_dict_equal,
@@ -31,6 +30,11 @@ from datalad.tests.utils_pytest import (
     with_tempfile,
     with_tree,
 )
+
+
+from datalad_deprecated.metadata.metadata import Metadata
+
+metadata = Metadata.__call__
 
 
 def _assert_metadata_empty(meta):

--- a/datalad_deprecated/metadata/tests/test_base.py
+++ b/datalad_deprecated/metadata/tests/test_base.py
@@ -16,9 +16,7 @@ from os.path import relpath
 
 from datalad.api import (
     Dataset,
-    aggregate_metadata,
     install,
-    metadata,
 )
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (
@@ -50,12 +48,18 @@ from datalad.utils import (
     ensure_unicode,
 )
 
-from ...metadata.metadata import (
+
+from datalad_deprecated.metadata.aggregate import AggregateMetaData
+from datalad_deprecated.metadata.metadata import (
     _get_containingds_from_agginfo,
     get_metadata_type,
     query_aggregated_metadata,
+    Metadata
 )
 
+
+metadata = Metadata.__call__
+aggregate_metadata = AggregateMetaData.__call__
 
 
 _dataset_hierarchy_template = {

--- a/datalad_deprecated/metadata/tests/test_extract_metadata.py
+++ b/datalad_deprecated/metadata/tests/test_extract_metadata.py
@@ -19,7 +19,6 @@ try:
 except Exception as e:
     raise SkipTest(f"Module 'libxmp' failed to load: {e}")
 
-from datalad.api import extract_metadata
 from datalad.coreapi import Dataset
 from datalad.tests.utils_pytest import (
     assert_in,
@@ -31,9 +30,9 @@ from datalad.tests.utils_pytest import (
     with_tempfile,
 )
 from datalad.utils import chpwd
+from datalad_deprecated.metadata.extract_metadata import ExtractMetadata
 
-
-
+extract_metadata = ExtractMetadata.__call__
 testpath = opj(dirname(dirname(dirname(__file__))), 'metadata', 'tests', 'data', 'xmp.pdf')
 
 

--- a/datalad_deprecated/metadata/tests/test_search.py
+++ b/datalad_deprecated/metadata/tests/test_search.py
@@ -26,7 +26,6 @@ from unittest.mock import (
 
 from datalad.api import (
     Dataset,
-    search,
 )
 from datalad.support.exceptions import NoDatasetFound
 from datalad.tests.utils_pytest import (
@@ -60,7 +59,10 @@ from ..metadata import (
 from ..search import (
     _listdict2dictlist,
     _meta2autofield_dict,
+    Search
 )
+
+search = Search.__call__
 
 
 @with_testsui(interactive=False)


### PR DESCRIPTION
- [x] Make sure, move is complete now, by running tests in https://github.com/datalad/datalad/pull/7014 against this patch rather than released version of datalad-deprecated. Proof: https://github.com/datalad/datalad/actions/runs/3329976467/jobs/5507873992
 
- [x] Enhance README to point out the new commands moved to this extension