### PR TITLE
Replace deprecated pkg_resources and distutils with modern alternatives

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ environment:
     - ID: Ubu22
       DTS: datalad_deprecated
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
-      PY: 3.9
+      PY: "3.10"
       INSTALL_SYSPKGS: python3-virtualenv exempi
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # system git-annex is way too old, use better one
@@ -75,13 +75,13 @@ environment:
       DTS: datalad_deprecated
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       # Python version specification is non-standard on windows
-      PY: 39-x64
+      PY: 310-x64
       INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
     - ID: MacP39core
       DTS: datalad_deprecated
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
-      PY: 3.9
+      PY: "3.10"
       INSTALL_SYSPKGS: exempi
       INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,30 +61,31 @@ environment:
     # is a need for debugging
 
     # Ubuntu core tests
-    - ID: Ubu20
+    - ID: Ubu22
       DTS: datalad_deprecated
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2204
+      PY: 3.9
       INSTALL_SYSPKGS: python3-virtualenv exempi
-      # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20201228T023115Z/pool/main/g/git-annex/git-annex_8.20201127-1_amd64.deb
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+      # system git-annex is way too old, use better one
+      INSTALL_GITANNEX: git-annex -m datalad/packages
     # Windows core tests
     - ID: WinP39core
       # ~35 min
       DTS: datalad_deprecated
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       # Python version specification is non-standard on windows
       PY: 39-x64
       INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
-    - ID: MacP38core
+    - ID: MacP39core
       DTS: datalad_deprecated
-      APPVEYOR_BUILD_WORKER_IMAGE: macOS
-      PY: 3.8
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
+      PY: 3.9
       INSTALL_SYSPKGS: exempi
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex -m datalad/packages
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
-      CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
+      CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
 matrix:
   allow_failures:
@@ -170,7 +171,7 @@ install:
       )
   - sh: python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
   # Missing system software
-  - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
+  - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacos-monterey\" ] && brew install -q ${INSTALL_SYSPKGS} ||  { sudo apt-get update -y && sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS}; } ) || true"
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
   - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -13,10 +13,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python "3.10"
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -13,10 +13,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install build & twine
         run: python -m pip install build twine

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Install build & twine
         run: python -m pip install build twine

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -28,10 +28,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install dependencies
       run: |
         pip install -r requirements-devel.txt

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -28,10 +28,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python "3.10"
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         pip install -r requirements-devel.txt

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -13,9 +13,9 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v4
       with:
-        node_version: 10
+        node-version: '18'
     - name: Install grunt
-      run:
+      run: |
         npm install grunt-cli
         npm install grunt
         npm install grunt-contrib-qunit@^4.0.0

--- a/_datalad_buildsupport/setup.py
+++ b/_datalad_buildsupport/setup.py
@@ -9,8 +9,8 @@
 import datetime
 import os
 
-from distutils.core import Command
-from distutils.errors import DistutilsOptionError
+from setuptools import Command
+from setuptools.errors import OptionError
 from os.path import (
     dirname,
     join as opj,
@@ -52,11 +52,11 @@ class BuildManPage(Command):
 
     def finalize_options(self):
         if self.manpath is None:
-            raise DistutilsOptionError('\'manpath\' option is required')
+            raise OptionError('\'manpath\' option is required')
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         if self.parser is None:
-            raise DistutilsOptionError('\'parser\' option is required')
+            raise OptionError('\'parser\' option is required')
         mod_name, func_name = self.parser.split(':')
         fromlist = mod_name.split('.')
         try:
@@ -171,9 +171,9 @@ class BuildRSTExamplesFromScripts(Command):
 
     def finalize_options(self):
         if self.expath is None:
-            raise DistutilsOptionError('\'expath\' option is required')
+            raise OptionError('\'expath\' option is required')
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         self.announce('Converting example scripts')
 
     def run(self):
@@ -203,7 +203,7 @@ class BuildConfigInfo(Command):
 
     def finalize_options(self):
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         self.announce('Generating configuration documentation')
 
     def run(self):

--- a/datalad_deprecated/metadata/tests/test_search.py
+++ b/datalad_deprecated/metadata/tests/test_search.py
@@ -17,7 +17,6 @@ from os.path import join as opj
 from pathlib import Path
 from shutil import copy
 from uuid import UUID
-from pkg_resources import EntryPoint
 
 from unittest.mock import (
     MagicMock,
@@ -390,18 +389,18 @@ def test_external_indexer():
                 "trubel": 2
             }.items()
 
-    class MockedEntryPoint(EntryPoint):
-        def __init__(self):
-            pass
+    class MockedEntryPoint:
+        name = 'extr1'
+        dist = 'MockedDist'
 
-        def load(self, *args):
+        def load(self):
             return MockedIndexer
 
-    def _mocked_iter_entry_points(group, metadata):
-        yield MockedEntryPoint()
+    def _mocked_entry_points(group):
+        return [MockedEntryPoint()]
 
-    with patch('pkg_resources.iter_entry_points',
-               MagicMock(side_effect=_mocked_iter_entry_points)):
+    with patch('importlib.metadata.entry_points',
+               MagicMock(side_effect=_mocked_entry_points)):
         index = _meta2autofield_dict({
             'datalad_unique_content_properties': {
                 'extr1': {
@@ -424,20 +423,18 @@ def test_external_indexer():
 
 def test_faulty_external_indexer():
     """ check that generic indexer is called on external indexer faults """
-    class MockedEntryPoint(EntryPoint):
-        def __init__(self):
-            self.name = 'MockedEntryPoint'
-            self.dist = 'Mock Distribution 1.1'
+    class MockedEntryPoint:
+        name = 'extr1'
+        dist = 'Mock Distribution 1.1'
 
-        def load(self, *args):
+        def load(self):
             raise Exception('Mocked indexer error')
 
-    def _mocked_iter_entry_points(group, metadata):
-        yield MockedEntryPoint()
+    def _mocked_entry_points(group):
+        return [MockedEntryPoint()]
 
-    with patch('pkg_resources.iter_entry_points',
-               MagicMock(side_effect=_mocked_iter_entry_points)):
-
+    with patch('importlib.metadata.entry_points',
+               MagicMock(side_effect=_mocked_entry_points)):
         index = _meta2autofield_dict({
             'datalad_unique_content_properties': {
                 'extr1': {
@@ -459,21 +456,18 @@ def test_faulty_external_indexer():
 
 def test_multiple_entry_points():
     """ check that generic indexer is called if multiple indexers exist for the same name """
-    class MockedEntryPoint(EntryPoint):
-        def __init__(self):
-            self.name = 'MockedEntryPoint'
-            self.dist = 'Mock Distribution 1.1'
+    class MockedEntryPoint:
+        name = 'extr1'
+        dist = 'Mock Distribution 1.1'
 
-        def load(self, *args):
+        def load(self):
             return 'Loaded MockedEntryPoint'
 
-    def _mocked_iter_entry_points(group, metadata):
-        yield MockedEntryPoint()
-        yield MockedEntryPoint()
+    def _mocked_entry_points(group):
+        return [MockedEntryPoint(), MockedEntryPoint()]
 
-    with patch('pkg_resources.iter_entry_points',
-               MagicMock(side_effect=_mocked_iter_entry_points)):
-
+    with patch('importlib.metadata.entry_points',
+               MagicMock(side_effect=_mocked_entry_points)):
         index = _meta2autofield_dict({
             'datalad_unique_content_properties': {
                 'extr1': {

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.10
 install_requires =
     datalad >= 0.18.0
     jsmin

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ filterwarnings =
     ignore:.*`publish` is deprecated
     # some not ours
     ignore:.*the imp module is deprecated in favour
-    ignore:.*The distutils package is deprecated
 markers =
     fail_slow
     githubci_osx

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,10 @@
+[tox]
+envlist = py3{10,11,12,13}
+
+[testenv]
+extras = devel
+commands = pytest {posargs}
+
 [pytest]
 filterwarnings =
     error:.*yield tests:pytest.PytestCollectionWarning
@@ -5,6 +12,7 @@ filterwarnings =
     # some not ours
     ignore:.*the imp module is deprecated in favour
 markers =
+    ai_generated
     fail_slow
     githubci_osx
     githubci_win


### PR DESCRIPTION
- Replace pkg_resources.iter_entry_points with importlib.metadata.entry_points
- Replace distutils.core.Command with setuptools.Command
- Replace distutils.errors.DistutilsOptionError with setuptools.errors.OptionError
- Update python_requires to >= 3.10 (Python 3.9 is EOL)
- Remove distutils deprecation warning filter from tox.ini

🤖 Generated with [Claude Code](https://claude.com/claude-code)